### PR TITLE
Added multiple attempts to MicrosoftTextApiClient's execution

### DIFF
--- a/mt/mshub/src/main/java/com/spartansoftwareinc/ws/okapi/mt/mshub/api/MicrosoftMTConnectorV3.java
+++ b/mt/mshub/src/main/java/com/spartansoftwareinc/ws/okapi/mt/mshub/api/MicrosoftMTConnectorV3.java
@@ -74,7 +74,7 @@ public class MicrosoftMTConnectorV3 extends BaseConnector {
             List<TranslateResponse> response = apiClient.translate(plainTexts, srcCode, trgCode,
                     getParameters().getAzureKey(), getParameters().getCategory());
             return convertResults(plainTexts, response);
-        } catch (IOException | URISyntaxException ex) {
+        } catch (IOException | URISyntaxException | InterruptedException ex) {
             LOG.error(ex);
             throw new RuntimeException("Translation request failed", ex);
         }


### PR DESCRIPTION
Rarely, there might be a connection timeout or other error. Instead of just failing the step, this will now make up to 3 total attempts before failing.