### PR TITLE
Created Automatic Action "Restore Segment's Placeholder Whitespace"

### DIFF
--- a/autoactions/mshub/pom.xml
+++ b/autoactions/mshub/pom.xml
@@ -7,7 +7,7 @@
     <version>1.8-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.spartansoftwareinc.ws.autoactions.mt</groupId>
+  <groupId>com.spartansoftwareinc.ws.autoactions.hubmt</groupId>
   <artifactId>okapi-ws-autoactions-mshub</artifactId>
   <packaging>jar</packaging>
 

--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/HubMTAutomaticAction.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/HubMTAutomaticAction.java
@@ -14,7 +14,6 @@ import com.idiominc.wssdk.linguistic.WSLanguage;
 import com.idiominc.wssdk.mt.WSMTResult;
 import com.spartansoftwareinc.ws.autoactions.SegmentMTAutomaticAction;
 import com.spartansoftwareinc.ws.autoactions.hubmt.WSPlaceholderUtil.PHData;
-import com.spartansoftwareinc.ws.autoactions.mt.Version;
 
 /**
  * <p>

--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemoval.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemoval.java
@@ -1,0 +1,143 @@
+package com.spartansoftwareinc.ws.autoactions.hubmt;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.log4j.Logger;
+
+import com.idiominc.wssdk.WSContext;
+import com.idiominc.wssdk.WSException;
+import com.idiominc.wssdk.asset.WSAssetTask;
+import com.idiominc.wssdk.asset.WSTextSegmentTranslation;
+import com.idiominc.wssdk.component.autoaction.WSActionResult;
+import com.idiominc.wssdk.component.autoaction.WSTaskAutomaticAction;
+import com.idiominc.wssdk.workflow.WSTask;
+import com.spartansoftwareinc.ws.autoactions.Version;
+
+/**
+ * <p>During Machine Translation, white spaces next to tags can be removed. This Auto Action can be added after a Machine Translation to fix those whitespaces</p>
+ *
+ * <p>Example: {@literal Hello <b>my</b> darling} --> {@literal Salut<b>disque</b>Darling!}</p>
+ * <p>
+ * These whitespaces need to be reinserted.
+ */
+public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
+
+    private final Logger LOG = Logger.getLogger(SegmentFixMTWhitespaceRemoval.class);
+
+    // This determines what to look for. The first and third capture groups determine what to restore from source,
+    // and the second capture group is used to compare equality.
+    private final static Pattern REGEX_PATTERN_TOKENS = Pattern.compile("(\\s)*\\{(\\d+)\\}(\\s)*");
+
+    private final String RETURN_DONE = "Done";
+
+    @Override
+    public String getDescription() {
+        return "Restores whitespaces around placeholders in the target translation, that were originally present in the source." +
+                "\nExample of missing whitespaces: Hello <b>my</b> darling --> Salut<b>disque</b>chéri!" +
+                "\nFixed: Hello <b>my</b> darling --> Salut <b>mon</b> chéri!";
+    }
+
+    @Override
+    public String getName() {
+        return "Restore Segment's Placeholder Whitespace";
+    }
+
+    @Override
+    public String getVersion() {
+        return Version.BANNER;
+    }
+
+    @Override
+    public String[] getReturns() {
+        return new String[] {RETURN_DONE};
+    }
+
+    @Override
+    public WSActionResult execute(WSContext context, Map parameters, WSTask task) throws WSException {
+        WSAssetTask assetTask;
+        Iterator textSegmentsIterator;
+        String resultMessage;
+        int numberOfTargetsModified = 0;
+
+        try {
+            // cast task to asset task
+            if (task instanceof WSAssetTask) {
+                assetTask = (WSAssetTask) task;
+            } else {
+                throw new WSException("Task was not an Asset Task");
+            }
+
+            // Grab the previous step's source and target translations
+            textSegmentsIterator = assetTask.getAssetTranslation().textSegmentIterator();
+
+            // Compare each translation and add in missing whitespaces
+            while (textSegmentsIterator.hasNext()) {
+                Object segmentObject = textSegmentsIterator.next();
+                if (!(segmentObject instanceof WSTextSegmentTranslation)) {
+                    continue;
+                }
+                WSTextSegmentTranslation segment = (WSTextSegmentTranslation) segmentObject;
+                String source = segment.getSource();
+                String target = segment.getTarget();
+                String fixed = fixWhitespace(source, target);
+                if (!target.equals(fixed)) {
+                    segment.setTarget(fixed);
+                    numberOfTargetsModified += 1;
+                }
+            }
+
+            resultMessage = String.format("%d segments had their placeholder whitespace restored.", numberOfTargetsModified);
+
+        } catch (Exception e) {
+            resultMessage = e.getMessage();
+            LOG.error("Unable to complete " + getName(), e);
+            return new WSActionResult(WSActionResult.ERROR, resultMessage);
+
+        }
+        return new WSActionResult(RETURN_DONE, resultMessage);
+    }
+
+
+    /**
+     * Compares the source to the target with the Regular Expression {@link #REGEX_PATTERN_TOKENS}. If they are different
+     * in any way, the source's string replaces the target's string in that specific spot. If the value of the token differs,
+     * a warning is thrown and no replacement will be made.
+     *
+     * @param source The string to compare to
+     * @param target The string that is being checked for differences
+     * @return The target string with the updates to the placeholders
+     */
+    public String fixWhitespace(String source, String target) {
+
+        Matcher source_matcher = REGEX_PATTERN_TOKENS.matcher(source);
+        Matcher target_matcher = REGEX_PATTERN_TOKENS.matcher(target);
+
+        StringBuffer final_target = new StringBuffer();
+
+        while (source_matcher.find() && target_matcher.find()) {
+
+            String source_item = source_matcher.group();
+            String target_item = target_matcher.group();
+
+            String source_value = source_matcher.group(2);
+            String target_value = target_matcher.group(2);
+
+            if (!source_value.equals(target_value)) {
+
+                LOG.warn(String.format("Source value %s did not match target value %s when comparing strings", source_item, target_item));
+            } else if (!source_item.equals(target_item)) {
+                target_matcher.appendReplacement(final_target, Matcher.quoteReplacement(source_item));
+            }
+
+        }
+
+        target_matcher.appendTail(final_target);
+
+        return final_target.toString();
+    }
+
+
+}

--- a/autoactions/mshub/src/main/resources/desc.xml
+++ b/autoactions/mshub/src/main/resources/desc.xml
@@ -1,3 +1,4 @@
 <components>
     <auto_action class="com.spartansoftwareinc.ws.autoactions.hubmt.HubMTAutomaticAction"/>
+    <auto_action class="com.spartansoftwareinc.ws.autoactions.hubmt.SegmentFixMTWhitespaceRemoval"/>
 </components>

--- a/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
+++ b/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
@@ -1,0 +1,41 @@
+package com.spartansoftwareinc.ws.autoactions.hubmt;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.spartansoftwareinc.ws.autoactions.hubmt.SegmentFixMTWhitespaceRemoval;
+
+public class SegmentFixMTWhitespaceRemovalTest {
+
+    private SegmentFixMTWhitespaceRemoval mtWhitespaceRemoval;
+
+    @Before
+    public void init() throws Exception {
+        mtWhitespaceRemoval = new SegmentFixMTWhitespaceRemoval();
+    }
+
+    @Test
+    public void fixWhitespaceTest() throws Exception {
+        testWhitespace("Hello {1}my{2} darling", "Salut{1}disque{2}Darling", "Salut {1}disque{2} Darling");
+        testWhitespace("{0} Hello {1}my{2} darling {999}", "{0}Salut{1}disque{2}Darling{999}", "{0} Salut {1}disque{2} Darling {999}");
+        testWhitespace("{2} what {3} {23 is {} that 3}", "{2}dangit{3}{23 bobby{}hill 3}", "{2} dangit {3} {23 bobby{}hill 3}");
+        testWhitespace("\t\n{1}   Whoooaaa theree buddy\t\t\n{2}\t{3}\n\nThat ain't{4}\t\tcool!{5}", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t\n{1}   Test test test\t\t\n{2}\t{3}\n\nahahhaha{4}\t\tawesome!{5}");
+
+    }
+
+    /**
+     *
+     * @param source Original string
+     * @param target Translated string
+     * @param fixed The proper translated string
+     */
+    private void testWhitespace(final String source, final String target, final String fixed) {
+
+        String test_fixed = mtWhitespaceRemoval.fixWhitespace(source, target);
+        assertEquals(fixed, test_fixed);
+    }
+
+
+}


### PR DESCRIPTION
This automatic action fixes issues with MTs leaving out whitespaces surrounding placeholders by restoring the whitespaces in the target that were present in the source.