### PR TITLE
Fixed Restore Whitespace Autoaction missing some whitespace types

### DIFF
--- a/autoactions/mshub/pom.xml
+++ b/autoactions/mshub/pom.xml
@@ -35,6 +35,17 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+   <dependency>
+    <groupId>org.yaml</groupId>
+    <artifactId>snakeyaml</artifactId>
+    <version>1.21</version>
+    <scope>compile</scope>
+   </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemoval.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemoval.java
@@ -1,20 +1,30 @@
 package com.spartansoftwareinc.ws.autoactions.hubmt;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
+import org.yaml.snakeyaml.Yaml;
 
 import com.idiominc.wssdk.WSContext;
 import com.idiominc.wssdk.WSException;
+import com.idiominc.wssdk.ais.WSAisManager;
+import com.idiominc.wssdk.ais.WSNode;
+import com.idiominc.wssdk.ais.WSNodeType;
 import com.idiominc.wssdk.asset.WSAssetTask;
 import com.idiominc.wssdk.asset.WSTextSegmentTranslation;
 import com.idiominc.wssdk.component.autoaction.WSActionResult;
 import com.idiominc.wssdk.component.autoaction.WSTaskAutomaticAction;
 import com.idiominc.wssdk.workflow.WSTask;
 import com.spartansoftwareinc.ws.autoactions.Version;
+import com.spartansoftwareinc.ws.autoactions.hubmt.config.SegmentWhitespaceFixYAMLConfig;
 
 /**
  * <p>During Machine Translation, white spaces next to tags can be removed. This Auto Action can be added after a Machine Translation to fix those whitespaces</p>
@@ -27,17 +37,23 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
 
     private final Logger LOG = Logger.getLogger(SegmentFixMTWhitespaceRemoval.class);
 
+    private static final String RETURN_DONE = "Done";
+    private static final String CONFIG_FILE_NAME = "mshub_autoaction_whitespace_fix.yml";
+    private static final String CONFIG_WS_LOCATION = "/Customization/Spartan/mshub_autoaction_whitespace_fix.yml";
+    private static final String CONFIG_WS_FOLDER = "/Customization/Spartan/";
+
     // This determines what to look for. The first and third capture groups determine what to restore from source,
     // and the second capture group is used to compare equality.
-    private final static Pattern REGEX_PATTERN_TOKENS = Pattern.compile("(\\s)*\\{(\\d+)\\}(\\s)*");
-
-    private final String RETURN_DONE = "Done";
+    private Pattern regexPatternTokens;
+    // Specifies the capture group to compare for validity. The specified capture group must match exactly.
+    private int captureGroupCompare;
 
     @Override
     public String getDescription() {
-        return "Restores whitespaces around placeholders in the target translation, that were originally present in the source." +
-                "\nExample of missing whitespaces: Hello <b>my</b> darling --> Salut<b>disque</b>chéri!" +
-                "\nFixed: Hello <b>my</b> darling --> Salut <b>mon</b> chéri!";
+        return "Restores whitespaces around placeholders in the target translation, that were originally present in the source. Uses Regex from a configuration file, which is generated if one does not exist." +
+                "\nExample of missing whitespaces: Hello <b>my</b> darling --> Salut<b>mon</b>chéri!" +
+                "\nFixed: Hello <b>my</b> darling --> Salut <b>mon</b> chéri!" +
+                "\nConfig location: " + CONFIG_WS_LOCATION;
     }
 
     @Override
@@ -60,6 +76,8 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
         WSAssetTask assetTask;
         Iterator textSegmentsIterator;
         String resultMessage;
+
+        setConfig(context.getAisManager());
         int numberOfTargetsModified = 0;
 
         try {
@@ -102,7 +120,7 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
 
 
     /**
-     * Compares the source to the target with the Regular Expression {@link #REGEX_PATTERN_TOKENS}. If they are different
+     * Compares the source to the target with the Regular Expression {@link #regexPatternTokens}. If they are different
      * in any way, the source's string replaces the target's string in that specific spot. If the value of the token differs,
      * a warning is thrown and no replacement will be made.
      *
@@ -112,8 +130,8 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
      */
     public String fixWhitespace(String source, String target) {
 
-        Matcher source_matcher = REGEX_PATTERN_TOKENS.matcher(source);
-        Matcher target_matcher = REGEX_PATTERN_TOKENS.matcher(target);
+        Matcher source_matcher = regexPatternTokens.matcher(source);
+        Matcher target_matcher = regexPatternTokens.matcher(target);
 
         StringBuffer final_target = new StringBuffer();
 
@@ -122,8 +140,8 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
             String source_item = source_matcher.group();
             String target_item = target_matcher.group();
 
-            String source_value = source_matcher.group(2);
-            String target_value = target_matcher.group(2);
+            String source_value = source_matcher.group(captureGroupCompare);
+            String target_value = target_matcher.group(captureGroupCompare);
 
             if (!source_value.equals(target_value)) {
 
@@ -137,6 +155,97 @@ public class SegmentFixMTWhitespaceRemoval extends WSTaskAutomaticAction {
         target_matcher.appendTail(final_target);
 
         return final_target.toString();
+    }
+
+    protected void setConfig(WSAisManager aisManager) throws WSException {
+
+        InputStream wsConfigFile;
+
+        final String FILE_TYPE = "Filesystem File";
+
+        if (aisManager != null) {
+            WSNode configFile = aisManager.getNode(CONFIG_WS_LOCATION);
+
+            // If config file is missing from server, copy the default config from the resources directory
+            if (configFile == null) {
+                WSNodeType fileNodeType = null;
+                WSNodeType[] nodeTypes = aisManager.getPossibleChildTypes(CONFIG_WS_FOLDER);
+                StringBuilder nodeTypesList = new StringBuilder();
+
+                for (WSNodeType nodeType : nodeTypes) {
+                    String name = nodeType.getName(Locale.ENGLISH);
+
+                    nodeTypesList.append("\"");
+                    nodeTypesList.append(name);
+                    nodeTypesList.append("\" ");
+                    if (FILE_TYPE.equals(name)) {
+                        fileNodeType = nodeType;
+                    }
+                }
+
+                if (fileNodeType == null) {
+                    throw new WSException("Could not find WSNodeType \"" + FILE_TYPE +
+                            "\"to create missing config file. Node types found: " + nodeTypesList);
+                }
+
+                // Copy file from resources to Worldserver
+                InputStream defaultConfigFile = loadConfigFromResources();
+                configFile = aisManager.create(CONFIG_WS_LOCATION, fileNodeType);
+                try {
+                    FileUtils.copyInputStreamToFile(defaultConfigFile, configFile.getFile());
+                } catch (IOException e) {
+                    throw new WSException(e);
+                }
+
+                LOG.warn("Config file not found in Worldserver. Created one at \"" + CONFIG_WS_LOCATION + "\"");
+            }
+
+            wsConfigFile = configFile.getInputStream();
+        } else {
+            // If not AIS manager (ran outside of Worldserver), just use resources file
+            wsConfigFile = loadConfigFromResources();
+        }
+
+        setConfiguration(wsConfigFile);
+
+        try {
+            wsConfigFile.close();
+        } catch (IOException e) {
+            throw new WSException(e);
+        }
+
+
+    }
+
+
+    protected InputStream loadConfigFromResources() throws WSException {
+        InputStream resource = getClass().getResourceAsStream(CONFIG_FILE_NAME);
+        if (resource == null) {
+            throw new WSException(new FileNotFoundException("Unable to load Resource " + CONFIG_FILE_NAME
+                    + " stored in package resources."));
+        }
+
+        return resource;
+    }
+
+    private void setConfiguration(InputStream inputStream) throws WSException {
+
+        SegmentWhitespaceFixYAMLConfig config = new Yaml().
+                loadAs(inputStream, SegmentWhitespaceFixYAMLConfig.class);
+
+        String pattern = config.getRegex();
+        if (pattern == null) {
+            throw new WSException("Unable to load \"regex\" from config file located at " + CONFIG_WS_LOCATION);
+        }
+        regexPatternTokens = Pattern.compile(pattern);
+
+
+        Integer group = config.getCaptureGroup();
+        if (group == null) {
+            throw new WSException("Unable to load \"captureGroup\" from config file located at " + CONFIG_WS_LOCATION);
+        }
+        captureGroupCompare = group;
+
     }
 
 

--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SegmentWhitespaceFixYAMLConfig.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SegmentWhitespaceFixYAMLConfig.java
@@ -1,0 +1,26 @@
+package com.spartansoftwareinc.ws.autoactions.hubmt.config;
+
+public class SegmentWhitespaceFixYAMLConfig {
+
+    private String regex;
+    private Integer captureGroup;
+
+    public SegmentWhitespaceFixYAMLConfig() {
+    }
+
+    public String getRegex() {
+        return regex;
+    }
+
+    public void setRegex(String regex) {
+        this.regex = regex;
+    }
+
+    public Integer getCaptureGroup() {
+        return captureGroup;
+    }
+
+    public void setCaptureGroup(Integer captureGroup) {
+        this.captureGroup = captureGroup;
+    }
+}

--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SegmentWhitespaceFixYAMLConfig.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SegmentWhitespaceFixYAMLConfig.java
@@ -3,7 +3,12 @@ package com.spartansoftwareinc.ws.autoactions.hubmt.config;
 public class SegmentWhitespaceFixYAMLConfig {
 
     private String regex;
-    private Integer captureGroup;
+    private Integer leftCaptureGroup;
+    private Integer leftIgnoreCaptureGroup;
+    private Integer centerCaptureGroup;
+    private Integer compareCaptureGroup;
+    private Integer rightIgnoreCaptureGroup;
+    private Integer rightCaptureGroup;
 
     public SegmentWhitespaceFixYAMLConfig() {
     }
@@ -16,11 +21,54 @@ public class SegmentWhitespaceFixYAMLConfig {
         this.regex = regex;
     }
 
-    public Integer getCaptureGroup() {
-        return captureGroup;
+    public Integer getLeftCaptureGroup() {
+        return leftCaptureGroup;
     }
 
-    public void setCaptureGroup(Integer captureGroup) {
-        this.captureGroup = captureGroup;
+    public void setLeftCaptureGroup(Integer leftCaptureGroup) {
+        this.leftCaptureGroup = leftCaptureGroup;
     }
+
+    public Integer getLeftIgnoreCaptureGroup() {
+        return leftIgnoreCaptureGroup;
+    }
+
+    public void setLeftIgnoreCaptureGroup(Integer leftIgnoreCaptureGroup) {
+        this.leftIgnoreCaptureGroup = leftIgnoreCaptureGroup;
+    }
+
+    public Integer getCenterCaptureGroup() {
+        return centerCaptureGroup;
+    }
+
+    public void setCenterCaptureGroup(Integer centerCaptureGroup) {
+        this.centerCaptureGroup = centerCaptureGroup;
+    }
+
+
+    public Integer getCompareCaptureGroup() {
+        return compareCaptureGroup;
+    }
+
+    public void setCompareCaptureGroup(Integer compareCaptureGroup) {
+        this.compareCaptureGroup = compareCaptureGroup;
+    }
+
+    public Integer getRightIgnoreCaptureGroup() {
+        return rightIgnoreCaptureGroup;
+    }
+
+    public void setRightIgnoreCaptureGroup(Integer rightIgnoreCaptureGroup) {
+        this.rightIgnoreCaptureGroup = rightIgnoreCaptureGroup;
+    }
+
+    public Integer getRightCaptureGroup() {
+        return rightCaptureGroup;
+    }
+
+    public void setRightCaptureGroup(Integer rightCaptureGroup) {
+        this.rightCaptureGroup = rightCaptureGroup;
+    }
+
+
 }

--- a/autoactions/mshub/src/main/resources/com/spartansoftwareinc/ws/autoactions/hubmt/mshub_autoaction_whitespace_fix.yml
+++ b/autoactions/mshub/src/main/resources/com/spartansoftwareinc/ws/autoactions/hubmt/mshub_autoaction_whitespace_fix.yml
@@ -1,2 +1,10 @@
-regex: "(?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*\\{(\\d+)\\}(?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*"
-captureGroup: 1
+# (?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*) Captures every single possible whitespace that surrounds the placeholder
+# ([\\p{P}&&[^{}]]?) Captures any punctuation, except { and }. It is the intersection of the set of all punctuation and the set with every character except { and }.
+# (\\{(\\d+)\\}) Captures placeholder and its value.
+regex: "((?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*)([\\p{P}&&[^{}]]?)(\\{(\\d+)\\})([\\p{P}&&[^{}]]?)((?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*)"
+leftCaptureGroup: 1
+leftIgnoreCaptureGroup: 2
+centerCaptureGroup: 3
+compareCaptureGroup: 4
+rightIgnoreCaptureGroup: 5
+rightCaptureGroup: 6

--- a/autoactions/mshub/src/main/resources/com/spartansoftwareinc/ws/autoactions/hubmt/mshub_autoaction_whitespace_fix.yml
+++ b/autoactions/mshub/src/main/resources/com/spartansoftwareinc/ws/autoactions/hubmt/mshub_autoaction_whitespace_fix.yml
@@ -1,0 +1,2 @@
+regex: "(?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*\\{(\\d+)\\}(?:[\\s\\h\\v\\u2009\\u200B]|\\uDB40\\uDC20)*"
+captureGroup: 1

--- a/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
+++ b/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
@@ -2,10 +2,10 @@ package com.spartansoftwareinc.ws.autoactions.hubmt;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.InputStream;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import com.spartansoftwareinc.ws.autoactions.hubmt.SegmentFixMTWhitespaceRemoval;
 
 public class SegmentFixMTWhitespaceRemovalTest {
 
@@ -14,6 +14,7 @@ public class SegmentFixMTWhitespaceRemovalTest {
     @Before
     public void init() throws Exception {
         mtWhitespaceRemoval = new SegmentFixMTWhitespaceRemoval();
+        mtWhitespaceRemoval.setConfig(null);
     }
 
     @Test
@@ -21,15 +22,46 @@ public class SegmentFixMTWhitespaceRemovalTest {
         testWhitespace("Hello {1}my{2} darling", "Salut{1}disque{2}Darling", "Salut {1}disque{2} Darling");
         testWhitespace("{0} Hello {1}my{2} darling {999}", "{0}Salut{1}disque{2}Darling{999}", "{0} Salut {1}disque{2} Darling {999}");
         testWhitespace("{2} what {3} {23 is {} that 3}", "{2}dangit{3}{23 bobby{}hill 3}", "{2} dangit {3} {23 bobby{}hill 3}");
-        testWhitespace("\t\n{1}   Whoooaaa theree buddy\t\t\n{2}\t{3}\n\nThat ain't{4}\t\tcool!{5}", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t\n{1}   Test test test\t\t\n{2}\t{3}\n\nahahhaha{4}\t\tawesome!{5}");
+        testWhitespace("\t\n  {1}   Whoooaaa theree buddy\t\t\n{2}\t{3}\n\nThat ain't{4}\t\tcool!{5}", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t\n  {1}   Test test test\t\t\n{2}\t{3}\n\nahahhaha{4}\t\tawesome!{5}");
+
+        testWhitespace("\t \n  {1}     Whoooaaa theree buddy\t\t\n{2}\t  {3}  \n\nThat ain't{4}\t\tcool!{5} ", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t \n  {1}     Test test test\t\t\n{2}\t  {3}  \n\nahahhaha{4}\t\tawesome!{5} ");
+
+        // Every single space found on https://unicode-table.com/en/search/?q=space. There might be some duplicates mixed in.
+        testWhitespace("Hello"+
+                " \t\n\u2006\u00A0\u2002\u2003\u2003\u202F  \u200B \uDB40\uDC20         　    " +
+                        "{150002023023}" +
+                        " \t\n\u2006\u00A0\u2002\u2003\u2003\u202F  \u200B \uDB40\uDC20         　    "+
+                        "there",
+                "Bonjour{150002023023}Là",
+                "Bonjour"+
+                " \t\n\u2006\u00A0\u2002\u2003\u2003\u202F  \u200B \uDB40\uDC20         　    " +
+                        "{150002023023}" +
+                        " \t\n\u2006\u00A0\u2002\u2003\u2003\u202F  \u200B \uDB40\uDC20         　    "+
+        "Là");
+
+
+    }
+
+    @Test
+    public void testConfigLoading() throws Exception {
+
+        InputStream config = mtWhitespaceRemoval.loadConfigFromResources();
+        java.util.Scanner s = new java.util.Scanner(config).useDelimiter("\\A");
+        StringBuilder configString = new StringBuilder();
+        while (s.hasNext()) {
+            configString.append(s.next());
+        }
+        config.close();
+
+        assertEquals("regex: \"(?:[\\\\s\\\\h\\\\v\\\\u2009\\\\u200B]|\\\\uDB40\\\\uDC20)*\\\\{(\\\\d+)\\\\}(?:[\\\\s\\\\h\\\\v\\\\u2009\\\\u200B]|\\\\uDB40\\\\uDC20)*\"\n" +
+                "captureGroup: 1", configString.toString());
 
     }
 
     /**
-     *
      * @param source Original string
      * @param target Translated string
-     * @param fixed The proper translated string
+     * @param fixed  The proper translated string
      */
     private void testWhitespace(final String source, final String target, final String fixed) {
 

--- a/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
+++ b/autoactions/mshub/src/test/java/com/spartansoftwareinc/ws/autoactions/hubmt/SegmentFixMTWhitespaceRemovalTest.java
@@ -1,8 +1,11 @@
 package com.spartansoftwareinc.ws.autoactions.hubmt;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -21,7 +24,7 @@ public class SegmentFixMTWhitespaceRemovalTest {
     public void fixWhitespaceTest() throws Exception {
         testWhitespace("Hello {1}my{2} darling", "Salut{1}disque{2}Darling", "Salut {1}disque{2} Darling");
         testWhitespace("{0} Hello {1}my{2} darling {999}", "{0}Salut{1}disque{2}Darling{999}", "{0} Salut {1}disque{2} Darling {999}");
-        testWhitespace("{2} what {3} {23 is {} that 3}", "{2}dangit{3}{23 bobby{}hill 3}", "{2} dangit {3} {23 bobby{}hill 3}");
+        testWhitespace("{2} what {3} {4} is {5} that {6}", "{2}dangit{3}{4} bobby{5}hill {6}", "{2} dangit {3} {4} bobby {5} hill {6}");
         testWhitespace("\t\n  {1}   Whoooaaa theree buddy\t\t\n{2}\t{3}\n\nThat ain't{4}\t\tcool!{5}", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t\n  {1}   Test test test\t\t\n{2}\t{3}\n\nahahhaha{4}\t\tawesome!{5}");
 
         testWhitespace("\t \n  {1}     Whoooaaa theree buddy\t\t\n{2}\t  {3}  \n\nThat ain't{4}\t\tcool!{5} ", "{1}Test test test{2}{3}ahahhaha{4}awesome!{5}", "\t \n  {1}     Test test test\t\t\n{2}\t  {3}  \n\nahahhaha{4}\t\tawesome!{5} ");
@@ -39,6 +42,32 @@ public class SegmentFixMTWhitespaceRemovalTest {
                         " \t\n\u2006\u00A0\u2002\u2003\u2003\u202F  \u200B \uDB40\uDC20         　    "+
         "Là");
 
+        testWhitespace("From the {1}Transfer Funds{2} {3}From{4} drop-down, choose the bank account the credit card was paid from.",
+
+                "Dans la liste déroulante {1}Transférer des fonds{2} {3}depuis{4}, choisissez le compte bancaire d'où le paiement a été émis.",
+                "Dans la liste déroulante {1}Transférer des fonds{2} {3}depuis{4}, choisissez le compte bancaire d'où le paiement a été émis.");
+
+        testWhitespace("{1}This is one long sentence{2} in order to {3}test{4} punctuation {5}detection{6} which is {7}quite{8} rare.",
+
+                "{1}This is now punctuated{2}, in order to {3}test!{4} Punctuation {5}detection,{6} while somewhat strange, is {7}important{8}!",
+                "{1}This is now punctuated{2}, in order to {3}test!{4} Punctuation {5}detection,{6} while somewhat strange, is {7}important{8}!");
+
+        testWhitespace("{1}This is one long sentence{2} in order to {3}test{4} punctuation {5}detection{6} which is {7}quite{8} rare.",
+
+                "{1}This is now punctuated{2}¿ In order to {3}test¡{4} Punctuation {5}detection¿{6} while somewhat strange, is {7}important{8}¡",
+                "{1}This is now punctuated{2}¿ In order to {3}test¡{4} Punctuation {5}detection¿{6} while somewhat strange, is {7}important{8}¡");
+
+        testWhitespace("{1}reorder{2} {3}test{4}.", "{3}test{4} {1}reorder{2}.", "{3}test{4}{1}reorder{2}.");
+
+        // Theoretical sentence beginning/end case
+//        testWhitespace("{1}Beginning and end{2}.",
+//
+//                "Not {1}beginning{2} or end.",
+//                "Not {1}beginning{2} or end.");
+//        testWhitespace("Not {1}beginning{2} or end.",
+//                "{1}Beginning and end{2}.",
+//                "{1}Beginning and end{2}.");
+
 
     }
 
@@ -52,10 +81,20 @@ public class SegmentFixMTWhitespaceRemovalTest {
             configString.append(s.next());
         }
         config.close();
+        // Check regex valid
+        String regex = mtWhitespaceRemoval.config.getRegex();
+        assertNotNull(regex);
+        Pattern compile = Pattern.compile(regex);
+        Matcher matcher = compile.matcher(" {123} ");
+        assertEquals(6, matcher.groupCount());
 
-        assertEquals("regex: \"(?:[\\\\s\\\\h\\\\v\\\\u2009\\\\u200B]|\\\\uDB40\\\\uDC20)*\\\\{(\\\\d+)\\\\}(?:[\\\\s\\\\h\\\\v\\\\u2009\\\\u200B]|\\\\uDB40\\\\uDC20)*\"\n" +
-                "captureGroup: 1", configString.toString());
-
+        // Check other params
+        assertEquals(mtWhitespaceRemoval.config.getLeftCaptureGroup(), new Integer(1));
+        assertEquals(mtWhitespaceRemoval.config.getLeftIgnoreCaptureGroup(), new Integer(2));
+        assertEquals(mtWhitespaceRemoval.config.getCenterCaptureGroup(), new Integer(3));
+        assertEquals(mtWhitespaceRemoval.config.getCompareCaptureGroup(), new Integer(4));
+        assertEquals(mtWhitespaceRemoval.config.getRightIgnoreCaptureGroup(), new Integer(5));
+        assertEquals(mtWhitespaceRemoval.config.getRightCaptureGroup(), new Integer(6));
     }
 
     /**


### PR DESCRIPTION
Restore Segment's Placeholder Whitespace was missing certain whitespace types, such as Non-breaking space.
The REGEX expression for hunting down these missing whitespaces has been updated to support horizontal whitespaces.
Also removed unnecessary grouping of the whitespace elements.
Added a configuration file so changes like this can be made without recompiling.