### PR TITLE
Added AEM Translation File Filter and set Okapi version to M37

### DIFF
--- a/bundle/src/main/resources/desc.xml
+++ b/bundle/src/main/resources/desc.xml
@@ -5,6 +5,7 @@
     <filter class="com.spartansoftwareinc.ws.okapi.filters.po.PoWSOkapiFilter"/>
     <filter class="com.spartansoftwareinc.ws.okapi.filters.xliff.XLIFFWSOkapiFilter"/>
     <filter class="com.spartansoftwareinc.ws.okapi.filters.yaml.YAMLWSOkapiFilter"/>
+    <filter class="com.spartansoftwareinc.ws.okapi.filters.aemtranslation.AEMTranslationFilter"/>
     <mt_adapter class="com.spartansoftwareinc.ws.okapi.mt.google.WSGoogleMTAdapter" />
     <mt_adapter class="com.spartansoftwareinc.ws.okapi.mt.mshub.WSMicrosoftMTAdapter" />
     <auto_action class="com.spartansoftwareinc.ws.autoactions.hubmt.HubMTAutomaticAction"/>

--- a/filters/aemtranslation/pom.xml
+++ b/filters/aemtranslation/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <url>http://maven.apache.org</url>
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spartansoftwareinc.ws.okapi.filters</groupId>
+    <artifactId>okapi-ws-filters</artifactId>
+    <version>1.8-SNAPSHOT</version>
+  </parent>
+
+  <groupId>com.spartansoftwareinc.ws.okapi.filters.aemtranslation</groupId>
+  <artifactId>okapi-ws-filters-aemtranslation</artifactId>
+  <name>Okapi AEM Translation File Filter for WorldServer</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spartansoftwareinc.ws.okapi.filters</groupId>
+      <artifactId>okapi-ws-filters-base</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-its</artifactId>
+      <version>${okapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-json</artifactId>
+      <version>${okapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-html</artifactId>
+      <version>${okapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-xmlstream</artifactId>
+      <version>${okapi.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi</groupId>
+      <artifactId>okapi-core</artifactId>
+      <version>${okapi.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.spartansoftwareinc.ws.okapi.filters</groupId>
+      <artifactId>okapi-ws-filters-base</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.1</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                </transformer>
+              </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>deployable</shadedClassifierName>
+              <relocations>
+                <relocation>
+                  <pattern>net.sf.okapi</pattern>
+                  <shadedPattern>${okapi.version}.net.sf.okapi</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.ibm.icu</pattern>
+                  <shadedPattern>okapi_ws_components.com.ibm.icu</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.slf4j</pattern>
+                  <shadedPattern>okapi_ws_components.org.slf4j</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.yaml</pattern>
+                  <shadedPattern>okapi_ws_components.org.yaml</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/filters/aemtranslation/src/main/java/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/AEMTranslationFilter.java
+++ b/filters/aemtranslation/src/main/java/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/AEMTranslationFilter.java
@@ -1,0 +1,243 @@
+package com.spartansoftwareinc.ws.okapi.filters.aemtranslation;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Stack;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spartansoftwareinc.ws.okapi.Version;
+import com.spartansoftwareinc.ws.okapi.filters.OkapiMultiFilterBridge;
+import com.spartansoftwareinc.ws.okapi.filters.WSOkapiMultiFilter;
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeNode;
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeRawDocumentNode;
+
+import net.sf.okapi.common.IParameters;
+import net.sf.okapi.common.filters.IFilter;
+import net.sf.okapi.common.resource.Code;
+import net.sf.okapi.common.resource.ISegments;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.common.resource.Segment;
+import net.sf.okapi.common.resource.TextContainer;
+import net.sf.okapi.common.resource.TextFragment;
+import net.sf.okapi.filters.html.HtmlFilter;
+import net.sf.okapi.filters.json.JSONFilter;
+import net.sf.okapi.filters.xml.XMLFilter;
+
+
+public class AEMTranslationFilter extends WSOkapiMultiFilter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AEMTranslationFilter.class);
+    private static final String FILTER_NAME = "Okapi AEM Translation File Filter";
+    private static final String FILTER_DESCRIPTION = "Filters an AEM Translation File. The file is an XML file which can contain JSON and HTML.";
+
+    private static final String XML_ITS_CONFIG_FILE = "aem_xml_translation_config.xml";
+    private static final String HTML_CONFIG_FILE = "html_filter_params.yml";
+
+    private enum SEGMENT_STATE {SENTENCE_SEGMENT, SUPERSCRIPT_SEGMENT}
+
+
+    public String getName() {
+        return FILTER_NAME;
+    }
+
+    public String getDescription() {
+        return FILTER_DESCRIPTION;
+    }
+
+    public String getVersion() {
+        return Version.BANNER;
+    }
+
+    protected FilterTreeRawDocumentNode buildTree(RawDocument srcRawDocument) {
+
+        final IFilter xmlFilter = getXMLFilter();
+        final IFilter jsonFilter = getJSONFilter();
+        final IFilter htmlFilter = getHTMLFilter();
+
+        // Apply first layer filter (XML Filter)
+        final FilterTreeRawDocumentNode root = new FilterTreeRawDocumentNode(srcRawDocument);
+        root.applyFilterAndCreateChildren(filterBridge, xmlFilter);
+
+        // If filter could not be applied, then document can't be parsed and need to skip
+        if (root.getChildren().size() == 0) {
+            return root;
+        }
+
+        // Apply second layer filter (JSON Filter)
+        root.applyFilterOnLeavesAndCreateChildren(filterBridge, jsonFilter);
+
+        // Apply third layer filter (HTML Filter)
+        root.applyFilterOnLeavesAndCreateChildren(filterBridge, htmlFilter);
+
+        // Fix <sup> elements at the end of sentences to be segmented alone
+        for (FilterTreeNode leaf : root.getLeaves()) {
+            ITextUnit textUnit = leaf.getTextUnit();
+            TextContainer segments = resegmentSupPlaceholders(textUnit.getSourceSegments());
+            textUnit.setSource(segments);
+        }
+
+        return root;
+
+    }
+
+    /**
+     * Resentments segments from a {@link ITextUnit}'s {@link ISegments} so that the superscripts at the end of a sentence
+     * are in their own segments.
+     * <p>
+     * Example input segmentation:
+     * 1. I see a black dog running down the street.<sup>1</sup> It appears to be lost.
+     * <p>
+     * Example output Segmentation:
+     * 1. I see a black dog running down the street.
+     * 2. <sup>1</sup>
+     * 3. It appears to be lost.
+     *
+     * @param segments The segments to resegnmented. Usually the result of {@link ITextUnit#getSourceSegments()}
+     * @return The newly segmented content.
+     */
+    private TextContainer resegmentSupPlaceholders(ISegments segments) {
+
+        final String LEFT_SUP = "<sup>";
+        final String RIGHT_SUP = "</sup>";
+        final char PERIOD = '.';
+
+        final TextContainer textContainer = new TextContainer();
+        final Stack<String> supStack = new Stack<>();
+        boolean rightAfterPeriod = false;
+        int segmentIdCount = 1;
+
+        for (Segment segment : segments) {
+            SEGMENT_STATE state = SEGMENT_STATE.SENTENCE_SEGMENT;
+            TextFragment newContent = new TextFragment();
+
+            final TextFragment currentContent = segment.getContent();
+            for (int i = 0; i < currentContent.length(); i++) {
+                char textChar = currentContent.charAt(i);
+
+                // If a placeholder, check if it's right after a period and is the <sup> placeholder.
+                // If it is, then start a new segment. Once a character is encountered that is outside of the <sup></sup>
+                // Element, then we start another segment.
+                if (TextFragment.isMarker(textChar)) {
+                    final Code code = currentContent.getCode(currentContent.charAt(++i));
+                    String outerData = code.getOuterData();
+                    if (rightAfterPeriod && LEFT_SUP.equals(outerData)) {
+                        state = SEGMENT_STATE.SUPERSCRIPT_SEGMENT;
+                        supStack.push(outerData);
+                        textContainer.append(new Segment(String.valueOf(segmentIdCount), newContent));
+                        segmentIdCount += 1;
+                        newContent = new TextFragment();
+                    } else if (LEFT_SUP.equals(outerData)) {
+                        supStack.push(outerData);
+                    } else if (RIGHT_SUP.equals(outerData) && state == SEGMENT_STATE.SUPERSCRIPT_SEGMENT) {
+                        supStack.pop();
+                    }
+                    newContent.append(code.clone());
+                } else {
+
+                    // The first character encountered outside of a <sup></sup> element, after in its own segment,
+                    // means we have reached the end of that segment and need to start another.
+                    if (state == SEGMENT_STATE.SUPERSCRIPT_SEGMENT && supStack.empty()) {
+                        textContainer.append(new Segment(String.valueOf(segmentIdCount), newContent));
+                        segmentIdCount += 1;
+
+                        newContent = new TextFragment();
+                        state = SEGMENT_STATE.SENTENCE_SEGMENT;
+                    }
+                    newContent.append(textChar);
+                    rightAfterPeriod = PERIOD == textChar;
+                }
+            }
+
+            textContainer.append(new Segment(String.valueOf(segmentIdCount), newContent));
+            segmentIdCount += 1;
+
+        }
+        textContainer.setHasBeenSegmentedFlag(true);
+        return textContainer;
+    }
+
+    @Override
+    protected void reconstructTreeFilters(FilterTreeRawDocumentNode root, OutputStream
+            targetOutput, OkapiMultiFilterBridge filterBridge) {
+        root.setTranslationOutput(targetOutput);
+        root.updateEntireTreesTranslations(filterBridge);
+    }
+
+
+    /**
+     * XML Filter is configured specifically for AEM Translation file using ITS rules from the config file {@value XML_ITS_CONFIG_FILE}.
+     *
+     * @return
+     */
+    private IFilter getXMLFilter() {
+        XMLFilter xmlFilter = new XMLFilter();
+        net.sf.okapi.filters.its.Parameters parameters = xmlFilter.getParameters();
+        try {
+            parameters.fromString(loadConfigFromResources(XML_ITS_CONFIG_FILE));
+        } catch (IOException e) {
+            LOG.error("Could not load config file {} for XMLFilter", XML_ITS_CONFIG_FILE);
+        }
+        return xmlFilter;
+    }
+
+    /**
+     * JSON Filter configured to extract stand alone strings, like those in arrays.
+     *
+     * @return
+     */
+    private IFilter getJSONFilter() {
+        JSONFilter jsonFilter = new JSONFilter();
+        net.sf.okapi.filters.json.Parameters parameters = jsonFilter.getParameters();
+        parameters.setExtractStandalone(true);
+        return jsonFilter;
+    }
+
+    /**
+     * HTML Filter is configured specifically for AEM Translation file using config file {@value HTML_CONFIG_FILE}.
+     *
+     * @return
+     */
+    private IFilter getHTMLFilter() {
+        HtmlFilter htmlFilter = new HtmlFilter();
+        IParameters parameters = htmlFilter.getParameters();
+        try {
+            parameters.fromString(loadConfigFromResources(HTML_CONFIG_FILE));
+        } catch (IOException e) {
+            LOG.error("Could not load config file {} for HtmlFilter", HTML_CONFIG_FILE);
+        }
+        return htmlFilter;
+    }
+
+    @Override
+    protected Logger getLoggerWithContext() {
+        return LOG;
+    }
+
+    private String loadConfigFromResources(String configFile) throws IOException {
+        InputStream resource = getClass().getResourceAsStream(configFile);
+        if (resource == null) {
+            throw new FileNotFoundException("Unable to load Resource " + configFile
+                    + " stored in package resources.");
+        }
+
+        StringBuilder sb = new StringBuilder();
+        String line;
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(resource, StandardCharsets.UTF_8))) {
+            while ((line = bufferedReader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+
+}
+

--- a/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/aem_xml_translation_config.xml
+++ b/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/aem_xml_translation_config.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' ?>
+<its:rules version='1.0'
+           xmlns:its='http://www.w3.org/2005/11/its'
+           xmlns:okp='okapi-framework:xmlfilter-options'
+           xmlns:itsx="http://www.w3.org/2008/12/its-extensions"
+>
+ <!-- Do not translate anything by default-->
+ <its:translateRule selector="//*" translate="no"/>
+
+ <!-- These elements can be translated. Ignores <translationObjectFile fileType=translation_export_summary>-->
+ <its:translateRule selector="//translationObjectFile[not(@fileType='translation_export_summary')]//translationObjectProperties//property" translate="yes" itsx:whiteSpaces="preserve"/>
+
+ <!-- More specific rule that will ignore both <translationObjectFile fileType=translation_export_summary> and <property fileUniqueID> -->
+ <!-- <its:translateRule selector="//translationObjectFile[not(@fileType='translation_export_summary')]//translationObjectProperties//property[not(@fileUniqueID)]" translate="yes"/>-->
+
+ <!-- Fixes issues with escaped characters -->
+ <okp:options escapeQuotes="no" escapeGT="yes" escapeNbsp="no"/>
+
+ <!-- See ITS specification at: http://www.w3.org/TR/its/ -->
+</its:rules>

--- a/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/html_filter_params.yml
+++ b/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/html_filter_params.yml
@@ -1,0 +1,267 @@
+assumeWellformed: false
+preserve_whitespace: true
+escapeCharacters: "&"
+attributes:
+  dir:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+    allElementsExcept: [base, basefront, head, html, meta, param, script]
+  title:
+    ruleTypes: [ATTRIBUTE_TRANS]
+  lang:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+  xml:lang:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+  aria-label:
+    ruleTypes: [ATTRIBUTE_TRANS]
+elements:
+  meta:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes:
+      content:
+        - [http-equiv, EQUALS, keywords]
+        - - name
+          - EQUALS
+          - [keywords, description]
+    writableLocalizableAttributes:
+      content:
+        - http-equiv
+        - EQUALS
+        - [content-language, content-type]
+      charset: null
+    readOnlyLocalizableAttributes:
+      content:
+        - name
+        - EQUALS
+        - [generator, author, progid, date]
+  area:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [accesskey, area, alt, download]
+  isindex:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [prompt]
+  option:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [label]
+  optgroup:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [label]
+  address:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  dt:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  dd:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h1:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h2:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h3:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h4:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h5:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h6:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  legend:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [accesskey]
+    idAttributes: [id]
+  li:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [value]
+    idAttributes: [id]
+  marquee:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  p:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+    elementType: paragraph
+  pre:
+    ruleTypes: [TEXTUNIT, PRESERVE_WHITESPACE]
+    idAttributes: [id]
+  td:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [abbr]
+    idAttributes: [id]
+  th:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+    translatableAttributes: [abbr]
+  title:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  track:
+    translatableAttributes: [label, srclang]
+    writableLocalizableAttributes: [src]
+  a:
+    ruleTypes: [INLINE]
+    elementType: link
+    translatableAttributes: [title, accesskey, download]
+    writableLocalizableAttributes: [href]
+  audio:
+    writableLocalizableAttributes: [src]
+  abbr:
+    ruleTypes: [INLINE]
+  acronym:
+    ruleTypes: [INLINE]
+  applet:
+    ruleTypes: [INLINE]
+    translatableAttributes: [alt]
+  b:
+    ruleTypes: [INLINE]
+    elementType: bold
+  base:
+    writableLocalizableAttributes: [src]
+  bdo:
+    ruleTypes: [INLINE]
+  big:
+    ruleTypes: [INLINE]
+  blink:
+    ruleTypes: [INLINE]
+  br:
+    ruleTypes: [INLINE]
+  button:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey, value]
+  cite:
+    ruleTypes: [INLINE]
+  code:
+    ruleTypes: [INLINE]
+  del:
+    ruleTypes: [INLINE]
+  dfn:
+    ruleTypes: [INLINE]
+  em:
+    ruleTypes: [INLINE]
+  embed:
+    ruleTypes: [INLINE]
+  font:
+    ruleTypes: [INLINE]
+  i:
+    ruleTypes: [INLINE]
+    elementType: italic
+  iframe:
+    ruleTypes: [INLINE]
+    translatableAttributes: [srcdoc]
+  img:
+    ruleTypes: [INLINE]
+    elementType: image
+    translatableAttributes: [title, alt]
+    writableLocalizableAttributes: [href, src]
+  input:
+    ruleTypes: [INLINE]
+    translatableAttributes:
+      alt:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      value:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      accesskey:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      title:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      placeholder: [type, NOT_EQUALS, dummy]
+  ins:
+    ruleTypes: [INLINE]
+  kbd:
+    ruleTypes: [INLINE]
+  label:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey]
+  map:
+    ruleTypes: [INLINE]
+  menuitem:
+    translatableAttributes: [label]
+  nobr:
+    ruleTypes: [INLINE]
+  object:
+    ruleTypes: [INLINE]
+    translatableAttributes: [standby]
+  param:
+    ruleTypes: [INLINE]
+    translatableAttributes: [value]
+  q:
+    ruleTypes: [INLINE]
+  s:
+    ruleTypes: [INLINE]
+  samp:
+    ruleTypes: [INLINE]
+  small:
+    ruleTypes: [INLINE]
+  select:
+    ruleTypes: [INLINE]
+  span:
+    ruleTypes: [INLINE]
+  spacer:
+    ruleTypes: [INLINE]
+  strike:
+    ruleTypes: [INLINE]
+  strong:
+    ruleTypes: [INLINE]
+  sub:
+    ruleTypes: [INLINE]
+  sup:
+    ruleTypes: [INLINE]
+  table:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [summary]
+  textarea:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey, placeholder]
+  tt:
+    ruleTypes: [INLINE]
+  u:
+    ruleTypes: [INLINE]
+    elementType: underlined
+  var:
+    ruleTypes: [INLINE]
+  wbr:
+    ruleTypes: [INLINE]
+  ruby:
+    ruleTypes: [INLINE]
+  rb:
+    ruleTypes: [INLINE]
+  rt:
+    ruleTypes: [INLINE]
+  rc:
+    ruleTypes: [INLINE]
+  rp:
+    ruleTypes: [INLINE]
+  rbc:
+    ruleTypes: [INLINE]
+  rtc:
+    ruleTypes: [INLINE]
+  symbol:
+    ruleTypes: [INLINE]
+  face:
+    ruleTypes: [INLINE]
+  .*:
+    ruleTypes: [EXCLUDE]
+    conditions: [translate, EQUALS, 'no']
+  style:
+    ruleTypes: [EXCLUDE]
+  stylesheet:
+    ruleTypes: [EXCLUDE]
+  script:
+    ruleTypes: [EXCLUDE]
+
+useCodeFinder: false
+codeFinderRules: "#v1\ncount.i=1\nrule0=a\nsample=Text <b>bold</b> <a name=\"abc\">\nuseAllRulesWhenTesting.b=false"

--- a/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/segmentation.xml
+++ b/filters/aemtranslation/src/main/resources/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/segmentation.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<srx xmlns="http://www.lisa.org/srx20" version="2.0">
+ <header segmentsubflows="yes" cascade="no">
+  <formathandle type="start" include="no"></formathandle>
+  <formathandle type="end" include="yes"></formathandle>
+  <formathandle type="isolated" include="no"></formathandle>
+ </header>
+ <body>
+  <languagerules>
+   <languagerule languagerulename="default">
+    <rule break="yes">
+     <beforebreak>(&lt;sup>[\d,]+&lt;/sup>)*\s*\.\s*(&lt;sup>[\d,]+&lt;/sup>)*</beforebreak>
+     <afterbreak>(&amp;amp;nbsp;)*\s*[a-zA-Z0-9]</afterbreak>
+    </rule>
+   </languagerule>
+  </languagerules>
+  <maprules>
+   <languagemap languagepattern=".*" languagerulename="default"></languagemap>
+  </maprules>
+ </body>
+</srx>

--- a/filters/aemtranslation/src/main/resources/desc.xml
+++ b/filters/aemtranslation/src/main/resources/desc.xml
@@ -1,0 +1,3 @@
+<components>
+    <filter class="com.spartansoftwareinc.ws.okapi.filters.aemtranslation.AEMTranslationFilter"/>
+</components>

--- a/filters/aemtranslation/src/test/java/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/AEMTranslationFilterTest.java
+++ b/filters/aemtranslation/src/test/java/com/spartansoftwareinc/ws/okapi/filters/aemtranslation/AEMTranslationFilterTest.java
@@ -1,0 +1,167 @@
+package com.spartansoftwareinc.ws.okapi.filters.aemtranslation;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.idiominc.wssdk.WSException;
+import com.idiominc.wssdk.component.filter.WSFilter;
+import com.spartansoftware.ws.okapi.filters.mock.MockWSSegmentReader;
+import com.spartansoftware.ws.okapi.filters.mock.MockWSSegmentReaderBuilder;
+import com.spartansoftwareinc.ws.okapi.filters.FilterTestHarness;
+import com.spartansoftwareinc.ws.okapi.filters.OkapiFilterBridge;
+import com.spartansoftwareinc.ws.okapi.filters.model.SegmentInfoHolder;
+
+public class AEMTranslationFilterTest {
+
+    @Test
+    public void testFilterSimple() throws Exception {
+
+
+        // Test 1
+        String testFile1 = "/test_aem_translation_file.xml";
+        List<SegmentInfoHolder> segments = new ArrayList<>();
+        addSegment(segments, "Test");
+        addSegment(segments, "This is a great test. Or is it?" + WSFilter.PLACEHOLDER + " Haha that's fine.",
+                "<br/>");
+        addSegment(segments, "Good:");
+        addSegment(segments, "None");
+        addSegment(segments, "Bad:");
+        addSegment(segments, WSFilter.PLACEHOLDER + "big" + WSFilter.PLACEHOLDER,
+                "<strong>", "</strong>");
+        testExtraction(testFile1, segments);
+
+    }
+
+    @Test
+    public void testFilterComplex() throws Exception {
+
+
+        // Test 1
+        String testFile1 = "/test_aem_translation_file2.xml";
+        List<SegmentInfoHolder> segments = new ArrayList<>();
+        addSegment(segments, "TEST Title");
+        addSegment(segments, "Some conent");
+        addSegment(segments, "More content");
+        addSegment(segments, "Application Note");
+        addSegment(segments, "Abstract");
+        addSegment(segments, "Sentence one.");
+        addSegment(segments, WSFilter.PLACEHOLDER + "1" + WSFilter.PLACEHOLDER + WSFilter.PLACEHOLDER + "2" + WSFilter.PLACEHOLDER, "<sup>", "</sup>", "<sup>", "</sup>");
+        addSegment(segments, " Sentence two.");
+        addSegment(segments, WSFilter.PLACEHOLDER + "3" + WSFilter.PLACEHOLDER, "<sup>", "</sup>");
+        addSegment(segments, "That was a great sentence. Now here's another! " + WSFilter.PLACEHOLDER + "4,5,6" + WSFilter.PLACEHOLDER, "<sup>", "</sup>");
+        addSegment(segments, "These things are evil:");
+        addSegment(segments, "See");
+        addSegment(segments, "Hear");
+        addSegment(segments, "Speak");
+        addSegment(segments, "x");
+        addSegment(segments, "y");
+        addSegment(segments, "a");
+        addSegment(segments, "b");
+        addSegment(segments, "This isn't you're basic test!  ");
+
+
+        testExtraction(testFile1, segments);
+
+    }
+
+
+    @Test
+    public void testFilterManifest() throws Exception {
+
+
+        // Test 1
+        String testFile1 = "/test_aem_translation_file3.xml";
+        List<SegmentInfoHolder> segments = new ArrayList<>();
+        testExtraction(testFile1, segments);
+
+    }
+
+    @Test
+    public void superScriptTest() throws Exception {
+
+
+        // Test 1
+        final String inputFile = "/super_script_test.xml";
+        final String outputFile = "/super_script_test_output.xml";
+
+        List<SegmentInfoHolder> segments = new ArrayList<>();
+        addSegment(segments, "Test words.");
+        addSegment(segments, WSFilter.PLACEHOLDER + "1-5" + WSFilter.PLACEHOLDER, "<sup>", "</sup>");
+        addSegment(segments, " well whadda you know.");
+        addSegment(segments, WSFilter.PLACEHOLDER + "6-10" + WSFilter.PLACEHOLDER, "<sup>", "</sup>");
+        testExtraction(inputFile, segments);
+
+
+        List<SegmentInfoHolder> segmentsOutput = new ArrayList<>();
+        addSegment(segmentsOutput, "Test words.");
+        addSegment(segmentsOutput, "{1}1-5{2}", "<sup>", "</sup>");
+        addSegment(segmentsOutput, " well whadda you know.");
+        addSegment(segmentsOutput, "{1}6-10{2}", "<sup>", "</sup>");
+        testMerging(inputFile, outputFile, segmentsOutput);
+
+
+    }
+
+
+    private void testExtraction(String inputFile, List<SegmentInfoHolder> segments) throws Exception {
+
+        final FilterTestHarness harness = new FilterTestHarness(new AEMTranslationFilter());
+        SegmentInfoHolder[] segmentsArray = new SegmentInfoHolder[segments.size()];
+        int i = 0;
+        for (SegmentInfoHolder s : segments) {
+            segmentsArray[i] = s;
+            i++;
+        }
+
+        // Create segments
+        harness.extractAndExpectSegments(inputFile, StandardCharsets.UTF_8, segmentsArray);
+
+    }
+
+    private void testMerging(String inputFile, String outputFile, List<SegmentInfoHolder> segments) throws IOException {
+        final FilterTestHarness harness = new FilterTestHarness(new AEMTranslationFilter());
+        SegmentInfoHolder[] segmentsArray = new SegmentInfoHolder[segments.size()];
+        int i = 0;
+        for (SegmentInfoHolder s : segments) {
+            segmentsArray[i] = s;
+            i++;
+        }
+
+        // Merge Segments
+        harness.mergeAndVerifyOutput(inputFile, outputFile, StandardCharsets.UTF_8, segments);
+    }
+
+
+    private MockWSSegmentReader prepareSegmentReader(String sourceFileResource,
+                                                     List<SegmentInfoHolder> translatedSegmentContent) {
+        MockWSSegmentReaderBuilder factory = new MockWSSegmentReaderBuilder();
+        factory.addMarkupSegment(sourceFileResource);
+        for (SegmentInfoHolder s : translatedSegmentContent) {
+            factory.addTextSegment(s.getEncodedText(), s.getPlaceholders())
+                    .addMarkupSegment(OkapiFilterBridge.SEGMENT_SEPARATOR);
+        }
+        return factory.build();
+    }
+
+    private URL loadConfigFromResources(String configFile) throws WSException {
+        URL resource = getClass().getResource(configFile);
+        if (resource == null) {
+            throw new WSException(new FileNotFoundException("Unable to load Resource " + configFile
+                    + " stored in package resources."));
+        }
+        return resource;
+    }
+
+    private void addSegment(List<SegmentInfoHolder> segments, String text, String... placeholders) {
+        segments.add(new SegmentInfoHolder(text, placeholders));
+    }
+
+
+}
+

--- a/filters/aemtranslation/src/test/resources/super_script_test.xml
+++ b/filters/aemtranslation/src/test/resources/super_script_test.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<translationObjectFile fileType="PAGE" sourcePath="/xyz">
+ <translationObjectProperties>
+  <property isMultiValue="false" nodePath="/xyz" propertyName="text">&lt;p&gt;Test words.&lt;sup&gt;1-5&lt;/sup&gt;&lt;/p&gt; &lt;p&gt; well whadda you know.&lt;sup&gt;6-10&lt;/sup&gt;</property>
+ </translationObjectProperties>
+</translationObjectFile>

--- a/filters/aemtranslation/src/test/resources/super_script_test_output.xml
+++ b/filters/aemtranslation/src/test/resources/super_script_test_output.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<translationObjectFile fileType="PAGE" sourcePath="/xyz">
+ <translationObjectProperties>
+  <property isMultiValue="false" nodePath="/xyz" propertyName="text">&lt;p&gt;Test words.&lt;sup&gt;1-5&lt;/sup&gt;&lt;/p&gt; &lt;p&gt; well whadda you know.&lt;sup&gt;6-10&lt;/sup&gt;</property>
+ </translationObjectProperties>
+</translationObjectFile>

--- a/filters/aemtranslation/src/test/resources/test_aem_translation_file.xml
+++ b/filters/aemtranslation/src/test/resources/test_aem_translation_file.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?><translationObjectFile fileType="PAGE" sourcePath="/mock/source">
+  <translationObjectProperties>
+    <invalid_property>THIS SHOULDN'T BE TRANSLATED</invalid_property>
+    <property isMultiValue="false" nodePath="/mock/path" propertyName="jcr:title">Test</property>
+    <property isMultiValue="false" nodePath="/mock/path" propertyName="jcr:description">This is a great test. Or is it?&lt;br/> Haha that's fine.</property>
+    <property isMultiValue="false" nodePath="/mock/path/table" propertyName="tableRowsJson">[{"0":["Good:"],"1":["None"]}]</property>
+    <property isMultiValue="false" nodePath="/mock/path/table" propertyName="tableRowsJson">[{"0":["Bad:"],"1":["&lt;strong>big&lt;/strong>"]}]</property>
+  </translationObjectProperties>
+</translationObjectFile>
+

--- a/filters/aemtranslation/src/test/resources/test_aem_translation_file2.xml
+++ b/filters/aemtranslation/src/test/resources/test_aem_translation_file2.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?><translationObjectFile fileType="PAGE" sourcePath="/content/waters/language-masters/zh/analysis-of-water-soluble-vitamins-in-infant-formula">
+  <translationObjectProperties>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">TEST Title</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Some conent</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">More content</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Application Note</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Abstract</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">&lt;p&gt;Sentence one.&lt;sup&gt;1&lt;/sup&gt;&lt;sup&gt;2&lt;/sup&gt; Sentence two.&lt;sup&gt;3&lt;/sup&gt;&lt;/p&gt;&#13;
+      &lt;p&gt;That was a great sentence. Now here's another! &lt;sup&gt;4,5,6&lt;/sup&gt;&lt;/p&gt;&#13;
+    </property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">&lt;p&gt;These things are evil:&lt;/p&gt;
+      &lt;ul&gt;
+      &lt;li&gt;See&lt;/li&gt;
+      &lt;li&gt;Hear&lt;/li&gt;
+      &lt;li&gt;Speak&lt;/li&gt;
+      &lt;/ul&gt;
+    </property>`
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">[{"0":["x"],"1":["y"]},{"0":["a"],"1":["b"]}]</property>
+    <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">This isn't you're basic test!&amp;nbsp; </property>
+  </translationObjectProperties>
+</translationObjectFile>

--- a/filters/aemtranslation/src/test/resources/test_aem_translation_file3.xml
+++ b/filters/aemtranslation/src/test/resources/test_aem_translation_file3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?><translationObjectFile fileType="translation_export_summary">
+ <translationObjectProperties>
+  <property fileUniqueID="ifd293bfio2nebf8bfo31nu1fv1pnfo191221" nodePath="/test/123"/>
+  <property fileUniqueID="ifd293bfio2nebf8bfo31nu1fv1pnfo191221" nodePath="/test/123/a"/>
+  <property fileUniqueID="ifd293bfio2nebf8bfo31nu1fv1pnfo191221" nodePath="/test/123/b"/>
+  <property fileUniqueID="ifd293bfio2nebf8bfo31nu1fv1pnfo191221" nodePath="/test/123/c"/>
+ </translationObjectProperties>
+</translationObjectFile>

--- a/filters/base/pom.xml
+++ b/filters/base/pom.xml
@@ -42,6 +42,18 @@
       <version>${okapi.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-json</artifactId>
+      <version>${okapi.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.okapi.filters</groupId>
+      <artifactId>okapi-filter-its</artifactId>
+      <version>${okapi.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/OkapiMultiFilterBridge.java
+++ b/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/OkapiMultiFilterBridge.java
@@ -1,0 +1,183 @@
+package com.spartansoftwareinc.ws.okapi.filters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.idiominc.wssdk.asset.WSMarkupSegment;
+import com.idiominc.wssdk.asset.WSSegment;
+import com.idiominc.wssdk.asset.WSTextSegment;
+import com.idiominc.wssdk.asset.WSTextSegmentPlaceholder;
+import com.idiominc.wssdk.component.filter.WSFilter;
+import com.idiominc.wssdk.component.filter.WSSegmentReader;
+import com.idiominc.wssdk.component.filter.WSSegmentWriter;
+import com.spartansoftwareinc.ws.okapi.filters.model.SegmentInfoHolder;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.resource.Code;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.Segment;
+import net.sf.okapi.common.resource.TextContainer;
+import net.sf.okapi.common.resource.TextFragment;
+
+public class OkapiMultiFilterBridge {
+    private static final String MISSING_CODE_MSG = "Missing matching Okapi code for placeholder '%s' => '%s', id '%d'";
+    private static final String MARKUP_SEG_VALIDATION_ERR_MSG = "Expected WSMarkupSegment but got '%s' instead! " +
+            "Content: '%s'";
+    private final Logger LOG = LoggerFactory.getLogger(OkapiMultiFilterBridge.class);
+
+    private static final String SEGMENT_SEPARATOR = "[SEGMENT SEPARATOR]";
+
+
+    /**
+     * Takes a ITextUnit and builds segments in WorldServer.
+     * @param wsSegmentWriter
+     * @param textUnit
+     */
+    public void processTextUnit(WSSegmentWriter wsSegmentWriter, ITextUnit textUnit) {
+        for (Segment segment : textUnit.getSourceSegments()) {
+            SegmentInfoHolder filterSegment = convertToCustomSegment(segment);
+            wsSegmentWriter.writeTextSegment(filterSegment.getEncodedText(),
+                    filterSegment.getPlaceholders());
+            LOG.info("Writing WS segment '{}'", filterSegment.getEncodedText());
+            wsSegmentWriter.writeMarkupSegment(SEGMENT_SEPARATOR);
+        }
+    }
+
+    private SegmentInfoHolder convertToCustomSegment(Segment segment) {
+        StringBuilder stringContent = new StringBuilder();
+        List<String> placeholders = new ArrayList<String>();
+        TextFragment textFragment = segment.getContent();
+        LOG.warn("Converting Segment to Worldserver SegmentInfoHolder: {}", textFragment.getCodedText());
+        for (int i = 0; i < textFragment.length(); i++) {
+            char textChar = textFragment.charAt(i);
+            if (TextFragment.isMarker(textChar)) {
+                Code code = textFragment.getCode(textFragment.charAt(++i));
+                placeholders.add(code.getOuterData());
+                stringContent.append(WSFilter.PLACEHOLDER);
+
+            } else {
+                stringContent.append(textChar);
+            }
+        }
+
+        return new SegmentInfoHolder(stringContent.toString(), listToArray(placeholders));
+    }
+
+    private String[] listToArray(List<String> list) {
+        return list.toArray(new String[list.size()]);
+    }
+
+    /**
+     * Reads segments in Worldserver and updates the TextUnit with the translated text.
+     * @param segmentReader
+     * @param targetLocale
+     * @param textUnit
+     */
+    public void processTextUnit(WSSegmentReader segmentReader, LocaleId targetLocale, ITextUnit textUnit) {
+        TextContainer target = parseTarget(textUnit, segmentReader);
+        textUnit.setTarget(targetLocale, target);
+    }
+
+    public void processTextUnits(List<ITextUnit> textUnits, WSSegmentReader segmentReader, LocaleId targetLocale) {
+        for (ITextUnit textUnit : textUnits) {
+            processTextUnit(segmentReader, targetLocale, textUnit);
+        }
+    }
+
+    private TextContainer parseTarget(ITextUnit textUnit, WSSegmentReader segmentReader) {
+        final TextContainer textContainer = textUnit.getSource().clone();
+
+        for (Segment okapiSegment : textContainer.getSegments()) {
+            WSSegment wsSegment = segmentReader.read();
+            List<WSTextSegment> wsTextSegments = new ArrayList<>();
+            for (; wsSegment instanceof WSTextSegment; wsSegment = segmentReader.read()) {
+                wsTextSegments.add((WSTextSegment) wsSegment);
+            }
+
+            processWSSegment(okapiSegment, wsTextSegments);
+
+            require(wsSegment instanceof WSMarkupSegment, String.format(MARKUP_SEG_VALIDATION_ERR_MSG,
+                    wsSegment.getClass().toString(), wsSegment.getContent()));
+        }
+        return textContainer;
+    }
+
+    private void processWSSegment(Segment okapiSegment, List<WSTextSegment> wsTextSegments) {
+        StringBuilder wsTextContent = new StringBuilder();
+        for (WSTextSegment wsTextSegment : wsTextSegments) {
+            final String content = wsTextSegment.getContent();
+            wsTextContent.append(content);
+        }
+        LOG.info("Reading WS segment '{}', Okapi Segment '{}'",
+                wsTextContent, okapiSegment.getContent().getCodedText());
+
+        TextFragment okapiFragment = okapiSegment.getContent();
+        TextFragment convertedTextFrag = writeToTextSegment(wsTextSegments, okapiFragment);
+        okapiSegment.setContent(convertedTextFrag);
+    }
+
+
+    private TextFragment writeToTextSegment(List<WSTextSegment> wsTextSegments, TextFragment okapiTextFragment) {
+        TextFragment targetOkapiFragment = new TextFragment();
+        List<Code> codes = okapiTextFragment.getCodes();
+
+        for (WSTextSegment wsTextSegment : wsTextSegments) {
+            String wsContent = wsTextSegment.getContent();
+            WSTextSegmentPlaceholder[] wsPlaceholders = wsTextSegment.getTargetPlaceholders();
+            int placeholderCounter = 0;
+            char[] wsContentChars = wsContent.toCharArray();
+            for (int i = 0; i < wsContentChars.length; i++) {
+                char contentChar = wsContentChars[i];
+                if (contentChar == '{') {
+                    String placeholder = getWSPlaceholder(i, wsContent);
+                    if (!placeholder.isEmpty()) {
+                        WSTextSegmentPlaceholder ph = wsPlaceholders[placeholderCounter++];
+                        Code code = getMatchingOkapiCode(codes, ph);
+                        require(code != null, String.format(MISSING_CODE_MSG, ph.toString(), ph.getText(), ph.getId()));
+                        targetOkapiFragment.append(code);
+                        i += placeholder.length() - 1;
+                    } else {
+                        targetOkapiFragment.append(contentChar);
+                    }
+                } else {
+                    targetOkapiFragment.append(contentChar);
+                }
+            }
+        }
+        return targetOkapiFragment;
+    }
+
+
+    private String getWSPlaceholder(int charIndex, String wsContent) {
+        String code = "";
+        int closingBraceIndex = wsContent.indexOf('}', charIndex);
+        if (closingBraceIndex >= 0) {
+            code = wsContent.substring(charIndex, 1 + closingBraceIndex);
+        }
+        return (code.matches("\\{[0-9]+\\}")) ? code : "";
+    }
+
+    private Code getMatchingOkapiCode(List<Code> codes, WSTextSegmentPlaceholder ph) {
+        for (Code code : codes) {
+            if (code.getOuterData().equals(ph.getText())) {
+                return code;
+            }
+        }
+        return null;
+    }
+
+    private void require(boolean condition, String message) {
+        if (!condition) {
+            LOG.error(message);
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+
+}
+
+
+

--- a/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/WSOkapiMultiFilter.java
+++ b/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/WSOkapiMultiFilter.java
@@ -1,0 +1,150 @@
+package com.spartansoftwareinc.ws.okapi.filters;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.idiominc.wssdk.WSContext;
+import com.idiominc.wssdk.WSRuntimeException;
+import com.idiominc.wssdk.ais.WSAisException;
+import com.idiominc.wssdk.ais.WSNode;
+import com.idiominc.wssdk.asset.WSAssetSegmentationException;
+import com.idiominc.wssdk.asset.WSSegment;
+import com.idiominc.wssdk.component.filter.WSFilter;
+import com.idiominc.wssdk.component.filter.WSSegmentReader;
+import com.idiominc.wssdk.component.filter.WSSegmentWriter;
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeNode;
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeRawDocumentNode;
+import com.spartansoftwareinc.ws.okapi.filters.utils.FilterUtil;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+
+public abstract class WSOkapiMultiFilter extends WSFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(WSOkapiMultiFilter.class);
+
+
+    protected OkapiMultiFilterBridge filterBridge = new OkapiMultiFilterBridge();
+
+    @Override
+    public void parse(WSContext context, WSNode srcContent, WSSegmentWriter wsSegmentWriter) {
+        try {
+
+            InputStream content = srcContent.getInputStream();
+            String encoding = srcContent.getEncoding();
+            LocaleId sourceAndTargetLocale = FilterUtil.getOkapiLocaleId(srcContent);
+            RawDocument srcRawDocument = new RawDocument(content, encoding, sourceAndTargetLocale, sourceAndTargetLocale);
+
+            // Save information for later retrieval
+            writeSourceAisPathSegment(srcContent, wsSegmentWriter);
+
+            // Build filter Tree
+            FilterTreeNode root = buildTree(srcRawDocument);
+
+            // Take the text units and add them as segments
+            List<FilterTreeNode> leaves = root.getLeaves();
+            for (FilterTreeNode leaf : leaves) {
+                // In some cases, the leaves of the tree may not be generated TextUnits, such as when the root node could not be translated.
+                if (leaf.getType() == FilterTreeNode.NODE_TYPE.FINAL_TEXT_UNIT) {
+                    ITextUnit textUnit = leaf.getTextUnit();
+                    filterBridge.processTextUnit(wsSegmentWriter, textUnit);
+                }
+            }
+
+        } catch (WSAisException ex) {
+            getLoggerWithContext().error("Failure to access content repository", ex);
+            throw new WSAssetSegmentationException(ex);
+        } catch (IllegalStateException ex) {
+            getLoggerWithContext().error(ex.getMessage(), ex);
+            throw new WSAssetSegmentationException(ex);
+        }
+    }
+
+    @Override
+    public void save(WSContext context, WSNode targetContent, WSSegmentReader segmentReader) {
+
+        try {
+            // Where the translated content will be put
+            OutputStream targetContentOutputStream = targetContent.getOutputStream();
+
+            // Get source data by reading the AIS path from the first segment, and then using that to read the file
+            String AISPath = readSourceAisPathSegment(segmentReader);
+            WSNode sourceContent = context.getAisManager().getNode(AISPath);
+            InputStream content = sourceContent.getInputStream();
+            String encoding = sourceContent.getEncoding();
+            LocaleId sourceLocale = FilterUtil.getOkapiLocaleId(sourceContent);
+            LocaleId targetLocale = sourceLocale;
+            RawDocument srcRawDocument = new RawDocument(content, encoding, sourceLocale, targetLocale);
+
+            FilterTreeRawDocumentNode root = buildTree(srcRawDocument);
+
+            // Update the leaves with the data from Worldserver
+            List<FilterTreeNode> leaves = root.getLeaves();
+            for (FilterTreeNode leaf : leaves) {
+                if (leaf.getType() == FilterTreeNode.NODE_TYPE.FINAL_TEXT_UNIT) {
+                    filterBridge.processTextUnit(segmentReader, targetLocale, leaf.getTextUnit());
+                }
+            }
+
+            // Update the tree and output the data
+            reconstructTreeFilters(root, targetContentOutputStream, filterBridge);
+
+            // Close the raw document's input stream
+            root.closeRawDocument();
+
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            getLoggerWithContext().error(ex.getMessage(), ex);
+            throw new WSAssetSegmentationException(ex);
+        }
+
+
+    }
+
+    protected abstract Logger getLoggerWithContext();
+
+    /**
+     * The tree is built both during {@link #parse(WSContext, WSNode, WSSegmentWriter)} and {@link #save(WSContext, WSNode, WSSegmentReader)}
+     * to ensure that the output is equal.
+     *
+     * @param srcRawDocument The original source document.
+     * @return The root of the tree.
+     */
+    protected abstract FilterTreeRawDocumentNode buildTree(RawDocument srcRawDocument);
+
+    protected abstract void reconstructTreeFilters(FilterTreeRawDocumentNode root, OutputStream
+            targetOutput, OkapiMultiFilterBridge filterBridge);
+
+    /**
+     * During import into WorldServer, we keep track of the source AIS path to use during export to preserve any
+     * metadata in the PO file by writing a markup segment containing the AIS path. We will later reparse this during
+     * export.
+     *
+     * @param srcContent    - AIS content
+     * @param segmentWriter - Writer to communicate with WorldServer
+     */
+    private void writeSourceAisPathSegment(WSNode srcContent, WSSegmentWriter segmentWriter) {
+        try {
+            segmentWriter.writeMarkupSegment(srcContent.getPath());
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new WSRuntimeException("Error serializing filter metadata", e);
+        }
+    }
+
+    private String readSourceAisPathSegment(WSSegmentReader segmentReader) {
+        try {
+            WSSegment segment = segmentReader.read();
+            return segment.getContent();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new WSRuntimeException("Error serializing filter metadata", e);
+        }
+    }
+
+}

--- a/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeNode.java
+++ b/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeNode.java
@@ -1,0 +1,328 @@
+package com.spartansoftwareinc.ws.okapi.filters.model;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spartansoftwareinc.ws.okapi.filters.OkapiMultiFilterBridge;
+
+import net.sf.okapi.common.Event;
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.filters.IFilter;
+import net.sf.okapi.common.filterwriter.IFilterWriter;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.common.resource.TextContainer;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+
+/**
+ * Designed to handle multiple levels of Filtering. The root node is based around a {@link RawDocument}, which is
+ * the source content. The children nodes are based around the {@link ITextUnit} which are a result of applying a filter
+ * to the parent node.
+ * <p>
+ * When a node is first created, it has no children and no filter applied. When a filter is applied to the node, the
+ * generated {@link ITextUnit}w from there are set as its children, and the filter used it set as
+ * {@link FilterTreeNode#filterApplied}.
+ * <p>
+ * To generate a tree:
+ * 1. Create the root node {@link FilterTreeRawDocumentNode#FilterTreeRawDocumentNode(RawDocument)}
+ * 2. Generate children with a filter {@link FilterTreeNode#applyFilterOnLeavesAndCreateChildren(OkapiMultiFilterBridge, IFilter)}
+ * 3. Repeat step 3 for each filter
+ * <p>
+ * To get the final units after generating a tree:
+ * 1. Grab them {@link FilterTreeNode#getLeaves()}
+ * 2. Grab the text units from each one {@link FilterTreeNode#getTextUnit()}
+ * <p>
+ * To create output document from translations:
+ * 1. Set the output stream of the root node{@link FilterTreeRawDocumentNode#setTranslationOutput(OutputStream)}, then use {@link }
+ * 2. Rebuild entire tree with the root node {@link FilterTreeNode#updateEntireTreesTranslations(OkapiMultiFilterBridge)}
+ * 3. Output will be in your Outputstream you originally set {@link FilterTreeRawDocumentNode#getTranslationOutput()}
+ */
+public abstract class FilterTreeNode {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FilterTreeNode.class);
+
+
+    private IFilter filterApplied = null;
+    private List<FilterTreeNode> children = new ArrayList<>();
+    private FilterTreeNode parent = null;
+
+    private RawDocument rawDocument = null;
+    private ITextUnit textUnit = null;
+
+    private String encoding = null;
+
+
+    public enum NODE_TYPE {
+        ROOT_RAW_DOCUMENT, INTERMEDIATE_TEXT_UNIT, FINAL_TEXT_UNIT, INVALID
+    }
+
+    public FilterTreeTextUnitNode addChild(ITextUnit child, String encoding, LocaleId sourceLocale, LocaleId targetLocale) {
+        final FilterTreeTextUnitNode node = new FilterTreeTextUnitNode(child, encoding, sourceLocale, targetLocale);
+        node.setParent(this);
+        this.children.add(node);
+        return node;
+    }
+
+    public List<FilterTreeNode> addChildren(List<ITextUnit> children, String encoding, LocaleId sourceLocale, LocaleId targetLocale) {
+        final List<FilterTreeNode> addedChildren = new ArrayList<>();
+        for (ITextUnit child : children) {
+            final FilterTreeTextUnitNode node = this.addChild(child, encoding, sourceLocale, targetLocale);
+            addedChildren.add(node);
+        }
+        return addedChildren;
+    }
+
+    public List<FilterTreeNode> getChildren() {
+        return children;
+    }
+
+    public List<FilterTreeNode> getChildren(int fromIndex, int toIndex) {
+        return children.subList(fromIndex, toIndex);
+    }
+
+    public FilterTreeNode getParent() {
+        return parent;
+    }
+
+    public void setParent(FilterTreeNode parent) {
+        this.parent = parent;
+    }
+
+
+    public boolean isLeaf() {
+        return children.isEmpty();
+    }
+
+    public boolean isRoot() {
+        return parent == null;
+    }
+
+    public IFilter getFilterApplied() {
+        return filterApplied;
+    }
+
+    public void setFilterApplied(IFilter filterApplied) {
+        this.filterApplied = filterApplied;
+    }
+
+
+    public RawDocument getRawDocument() {
+        return rawDocument;
+    }
+
+    public void setRawDocument(RawDocument rawDocument) {
+        this.rawDocument = rawDocument;
+    }
+
+    public ITextUnit getTextUnit() {
+        return textUnit;
+    }
+
+    public void setTextUnit(ITextUnit textUnit) {
+        this.textUnit = textUnit;
+    }
+
+    public NODE_TYPE getType() {
+        if (textUnit != null) {
+            if (isLeaf()) {
+                return NODE_TYPE.FINAL_TEXT_UNIT;
+            } else {
+                return NODE_TYPE.INTERMEDIATE_TEXT_UNIT;
+            }
+        }
+        if (rawDocument != null) {
+            return NODE_TYPE.ROOT_RAW_DOCUMENT;
+        }
+
+        return NODE_TYPE.INVALID;
+
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public List<FilterTreeNode> postOrderTraversal() {
+
+        List<FilterTreeNode> postOrderList = new ArrayList<>();
+        traversePost(this, postOrderList);
+        return postOrderList;
+    }
+
+
+    private void traversePost(FilterTreeNode node, List<FilterTreeNode> postOrderTraversalList) {
+
+        for (FilterTreeNode child : node.getChildren()) {
+            traversePost(child, postOrderTraversalList);
+        }
+        postOrderTraversalList.add(node);
+    }
+
+    public List<FilterTreeNode> getLeaves() {
+        List<FilterTreeNode> leaves = new ArrayList<>();
+        for (FilterTreeNode child : preOrderTraversal()) {
+            if (child.isLeaf()) {
+                leaves.add(child);
+            }
+
+        }
+        return leaves;
+    }
+
+    public List<FilterTreeNode> preOrderTraversal() {
+        List<FilterTreeNode> preOrderList = new ArrayList<>();
+        traversePre(this, preOrderList);
+        return preOrderList;
+    }
+
+    private void traversePre(FilterTreeNode node, List<FilterTreeNode> preOrderTraversalList) {
+        preOrderTraversalList.add(node);
+        for (FilterTreeNode child : node.getChildren()) {
+            traversePre(child, preOrderTraversalList);
+        }
+    }
+
+    /**
+     * Will take the input filter, apply it to the current node, and then create a child {@link FilterTreeTextUnitNode} for each {@link ITextUnit}.
+     *
+     * @param filterBridge
+     * @param filter
+     */
+    public abstract void applyFilterAndCreateChildren(OkapiMultiFilterBridge filterBridge, IFilter filter);
+
+    /**
+     * Traverses the entire tree and applies the {@link #applyFilterAndCreateChildren(OkapiMultiFilterBridge, IFilter)} method on every leaf.
+     *
+     * @param filterBridge
+     * @param filter
+     */
+    public void applyFilterOnLeavesAndCreateChildren(OkapiMultiFilterBridge filterBridge, IFilter filter) {
+        List<FilterTreeNode> leaves = this.getLeaves();
+        for (FilterTreeNode node : leaves) {
+            node.applyFilterAndCreateChildren(filterBridge, filter);
+        }
+    }
+
+    /**
+     * Reads the children's target translations, and updates the target translation of the current node.
+     *
+     * @param filterBridge
+     */
+    public abstract void updateWithChildrensTranslations(OkapiMultiFilterBridge filterBridge);
+
+    /**
+     * Reads the children's target translations, and updates the target translation of the current node.
+     *
+     * @param sourceRawDocument The original, untranslated, content of the current node.
+     * @param outputTranslation The output where you want the translated content to go
+     * @param children          The children to use. This is a parameter because not all children might not be used.
+     */
+    protected void updateChildrenWithTranslations(RawDocument sourceRawDocument, OutputStream outputTranslation, List<FilterTreeNode> children) {
+
+        IFilter filter = getFilterApplied();
+
+        // Prepare the Okapi writer
+        filter.open(sourceRawDocument);
+        IFilterWriter filterWriter = filter.createFilterWriter();
+        filterWriter.setOptions(sourceRawDocument.getTargetLocale(), getEncoding());
+        filterWriter.setOutput(outputTranslation);
+
+
+        // Grab the ITextUnits
+        List<ITextUnit> childrenTextUnits = new ArrayList<>();
+        for (FilterTreeNode child : children) {
+            childrenTextUnits.add(child.getTextUnit());
+        }
+
+        // Execute the writing
+        int textUnitIndex = 0;
+        try {
+            while (filter.hasNext()) {
+                Event event = filter.next();
+                if (event.isTextUnit()) {
+
+                    // Update the text unit with the translated text unit
+                    ITextUnit untranslatedTextUnit = event.getTextUnit();
+                    ITextUnit translatedTextUnit = childrenTextUnits.get(textUnitIndex);
+                    TextContainer translatedTarget = translatedTextUnit.getTarget(sourceRawDocument.getTargetLocale());
+                    if (translatedTarget != null) {
+                        untranslatedTextUnit.setTarget(sourceRawDocument.getTargetLocale(), translatedTarget.clone());
+                    }
+                    textUnitIndex++;
+                }
+                filterWriter.handleEvent(event);
+            }
+        } finally {
+            filter.close();
+
+        }
+    }
+
+    public OutputStream getTranslationOutput() {
+        throw new NotImplementedException();
+    }
+
+    /**
+     * From the leaves all the way to the root, update all the translated text.
+     *
+     * @param filterBridge
+     */
+    public void updateEntireTreesTranslations(OkapiMultiFilterBridge filterBridge) {
+        for (FilterTreeNode node : this.postOrderTraversal()) {
+            if (!node.isLeaf()) {
+                node.updateWithChildrensTranslations(filterBridge);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        NODE_TYPE type = getType();
+        String filter = "";
+        if (filterApplied != null) {
+            filter = filterApplied.getName();
+        }
+        if (type == NODE_TYPE.ROOT_RAW_DOCUMENT) {
+            return String.format("%s %s %s %s", type.name(), getEncoding(), filter, rawDocument);
+        } else {
+            TextContainer target = textUnit.getTarget(((FilterTreeTextUnitNode) this).getTargetLocale());
+            return String.format("%s %s %s %s ===> %s", type.name(), getEncoding(), filter, textUnit, target);
+        }
+    }
+
+    /**
+     * @param filter           The filter to use and apply to this node
+     * @param srcRawDocument   The document to read
+     * @param closeRawDocument Close the document, which may have a stream open, after creating the text units.
+     * @return
+     */
+    public List<ITextUnit> createTextUnits(IFilter filter, RawDocument srcRawDocument, boolean closeRawDocument) {
+        List<ITextUnit> textUnits = new ArrayList<>();
+        filter.open(srcRawDocument);
+        try {
+            while (filter.hasNext()) {
+                Event event = filter.next();
+                if (event.isTextUnit()) {
+                    ITextUnit textUnit = event.getTextUnit();
+                    if (textUnit.isTranslatable()) {
+                        textUnits.add(textUnit);
+                    }
+                }
+            }
+            return textUnits;
+        } finally {
+            if (closeRawDocument) {
+                filter.close();
+            }
+        }
+    }
+}

--- a/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeRawDocumentNode.java
+++ b/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeRawDocumentNode.java
@@ -1,0 +1,80 @@
+package com.spartansoftwareinc.ws.okapi.filters.model;
+
+import java.io.OutputStream;
+import java.util.List;
+
+import com.spartansoftwareinc.ws.okapi.filters.OkapiMultiFilterBridge;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.filters.IFilter;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+
+/**
+ * This represents the actual document, and should always be the root node. It's children should always be {@link FilterTreeTextUnitNode}s.
+ */
+public class FilterTreeRawDocumentNode extends FilterTreeNode {
+
+    private OutputStream translationOutput;
+
+
+    public FilterTreeRawDocumentNode(RawDocument rawDocument) {
+        this(rawDocument, null);
+    }
+
+    public FilterTreeRawDocumentNode(RawDocument rawDocument, IFilter filterApplied) {
+        setRawDocument(rawDocument);
+        setFilterApplied(filterApplied);
+        translationOutput = null;
+    }
+
+    @Override
+    public void applyFilterAndCreateChildren(OkapiMultiFilterBridge filterBridge, IFilter filter) {
+        final RawDocument rawDocument = getRawDocument();
+        List<ITextUnit> textUnits = createTextUnits(filter, getRawDocument(), false);
+        if (textUnits.size() > 0) {
+            LocaleId sourceLocale = rawDocument.getSourceLocale();
+            LocaleId targetLocale = rawDocument.getTargetLocale();
+            if (sourceLocale == null) {
+                throw new RuntimeException("Source Locale cannot be null");
+            }
+            if (targetLocale == null) {
+                throw new RuntimeException("Target Locale cannot be null");
+            }
+
+            addChildren(textUnits, getEncoding(), sourceLocale, targetLocale);
+            setFilterApplied(filter);
+        }
+
+    }
+
+    @Override
+    public void updateWithChildrensTranslations(OkapiMultiFilterBridge filterBridge) {
+
+        if (isLeaf()) {
+            throw new RuntimeException("Cannot update a leaf node with children's translations because it has no children");
+        }
+
+        updateChildrenWithTranslations(getRawDocument(), translationOutput, getChildren());
+    }
+
+    /**
+     * Closes the input stream, making it no longer accessible.
+     */
+    public void closeRawDocument() {
+        getRawDocument().close();
+    }
+
+    public OutputStream getTranslationOutput() {
+        return translationOutput;
+    }
+
+    public void setTranslationOutput(OutputStream translationOutput) {
+        this.translationOutput = translationOutput;
+    }
+
+    @Override
+    public String getEncoding() {
+        return getRawDocument().getEncoding();
+    }
+}

--- a/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeTextUnitNode.java
+++ b/filters/base/src/main/java/com/spartansoftwareinc/ws/okapi/filters/model/FilterTreeTextUnitNode.java
@@ -1,0 +1,131 @@
+package com.spartansoftwareinc.ws.okapi.filters.model;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spartansoftwareinc.ws.okapi.filters.OkapiMultiFilterBridge;
+
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.filters.IFilter;
+import net.sf.okapi.common.resource.ISegments;
+import net.sf.okapi.common.resource.ITextUnit;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.common.resource.Segment;
+import net.sf.okapi.common.resource.TextContainer;
+
+public class FilterTreeTextUnitNode extends FilterTreeNode {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FilterTreeTextUnitNode.class);
+
+
+    private LocaleId sourceLocale;
+    private LocaleId targetLocale;
+
+    private Map<Integer, List<FilterTreeNode>> segmentMap;
+
+    public FilterTreeTextUnitNode(ITextUnit textUnit, String encoding, LocaleId sourceLocale, LocaleId targetLocale) {
+        this(textUnit, encoding, sourceLocale, targetLocale, null);
+    }
+
+    public FilterTreeTextUnitNode(ITextUnit textUnit, String encoding, LocaleId sourceLocale, LocaleId targetLocale, IFilter filterApplied) {
+        setTextUnit(textUnit);
+        this.setEncoding(encoding);
+        this.sourceLocale = sourceLocale;
+        this.targetLocale = targetLocale;
+        this.setFilterApplied(filterApplied);
+
+    }
+
+
+    @Override
+    public void applyFilterAndCreateChildren(OkapiMultiFilterBridge filterBridge, IFilter filter) {
+        segmentMap = new HashMap<>();
+        try {
+            ISegments segments = getTextUnit().getSource().getSegments();
+            int segmentIndex = 0;
+            for (Segment segment : segments) {
+                String textContent = segment.getContent().getCodedText();
+                final ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(textContent.getBytes(getEncoding()));
+                RawDocument mockRawDocument = new RawDocument(byteArrayInputStream, getEncoding(), sourceLocale, targetLocale);
+                mockRawDocument.setEncoding(getEncoding());
+                List<ITextUnit> newUnits = createTextUnits(filter, mockRawDocument, true);
+                if (newUnits.size() > 0) {
+                    List<FilterTreeNode> newChildren = addChildren(newUnits, getEncoding(), sourceLocale, targetLocale);
+                    setFilterApplied(filter);
+                    segmentMap.put(segmentIndex, newChildren);
+                }
+                segmentIndex += 1;
+            }
+        } catch (Exception ignored) {
+
+        }
+
+    }
+
+    @Override
+    public void updateWithChildrensTranslations(OkapiMultiFilterBridge filterBridge) {
+
+        if (isLeaf()) {
+            throw new RuntimeException("Cannot update a leaf node with children's translations because it has no children");
+        }
+
+        // If no target is set, add one
+        TextContainer targetContainer = getTextUnit().getTarget(getTargetLocale());
+        if (targetContainer == null) {
+            getTextUnit().setTarget(getTargetLocale(), getTextUnit().getSource().clone());
+            targetContainer = getTextUnit().getTarget(getTargetLocale());
+        }
+
+        // Loop through each segment and update with the target translation
+        ISegments targetSegments = targetContainer.getSegments();
+        int segmentIndex = 0;
+        for (Segment segment : targetSegments) {
+            List<FilterTreeNode> children = segmentMap.get(segmentIndex);
+
+            // Create raw document from text Unit
+            InputStream text = null;
+            try {
+                text = new ByteArrayInputStream(getTextUnit().getSource().toString().getBytes(getEncoding()));
+            } catch (UnsupportedEncodingException e) {
+                LOG.error("Encoding {} not supported in this node {}.\n{}", getEncoding(), toString(), e.getMessage());
+            }
+            RawDocument mockRawDocument = new RawDocument(text, getEncoding(), sourceLocale, targetLocale);
+            mockRawDocument.setEncoding(getEncoding());
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            // Update outputStream with the translation
+            updateChildrenWithTranslations(mockRawDocument, outputStream, children);
+
+            // Update the segment with outputStream
+            try {
+                segment.getContent().setCodedText(outputStream.toString(getEncoding()));
+            } catch (UnsupportedEncodingException e) {
+                LOG.error("Encoding {} not supported in this node {}.\n{}", getEncoding(), toString(), e.getMessage());
+            }
+        }
+    }
+
+    public LocaleId getSourceLocale() {
+        return sourceLocale;
+    }
+
+    public void setSourceLocale(LocaleId sourceLocale) {
+        this.sourceLocale = sourceLocale;
+    }
+
+    public LocaleId getTargetLocale() {
+        return targetLocale;
+    }
+
+    public void setTargetLocale(LocaleId targetLocale) {
+        this.targetLocale = targetLocale;
+    }
+}

--- a/filters/base/src/test/java/com/spartansoftwareinc/ws/okapi/filters/TestFilterTreeNode.java
+++ b/filters/base/src/test/java/com/spartansoftwareinc/ws/okapi/filters/TestFilterTreeNode.java
@@ -1,0 +1,130 @@
+package com.spartansoftwareinc.ws.okapi.filters;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeNode;
+import com.spartansoftwareinc.ws.okapi.filters.model.FilterTreeRawDocumentNode;
+
+import net.sf.okapi.common.IParameters;
+import net.sf.okapi.common.LocaleId;
+import net.sf.okapi.common.filters.IFilter;
+import net.sf.okapi.common.resource.RawDocument;
+import net.sf.okapi.filters.html.HtmlFilter;
+import net.sf.okapi.filters.json.JSONFilter;
+import net.sf.okapi.filters.xml.XMLFilter;
+
+public class TestFilterTreeNode {
+
+
+    @Test
+    public void testBuild() throws Exception {
+
+        OkapiMultiFilterBridge filterBridge = new OkapiMultiFilterBridge();
+        RawDocument srcRawDocument = rawDocumentFromTestFile("json_mixed_input.xml", LocaleId.ENGLISH, LocaleId.ENGLISH);
+
+        IFilter xmlFilter = getXMLFIlter("xml_filter_params.xml");
+        IFilter jsonFilter = getJSONFilter();
+        IFilter htmlFilter = getHTMLFilter("html_filter_params.yml");
+
+        // Layer 1
+        FilterTreeRawDocumentNode root = new FilterTreeRawDocumentNode(srcRawDocument);
+        root.applyFilterAndCreateChildren(filterBridge, xmlFilter);
+
+        // Layer 2
+        List<FilterTreeNode> secondLayer = root.getLeaves();
+        for (FilterTreeNode node : secondLayer) {
+            node.applyFilterAndCreateChildren(filterBridge, jsonFilter);
+        }
+
+        // Layer 3
+        List<FilterTreeNode> thirdLayer = root.getLeaves();
+        for (FilterTreeNode node : thirdLayer) {
+            node.applyFilterAndCreateChildren(filterBridge, htmlFilter);
+        }
+
+        // Update the tree and output the data
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        root.setTranslationOutput(byteArrayOutputStream);
+        for (FilterTreeNode node : root.postOrderTraversal()) {
+            if (!node.isLeaf()) {
+                node.updateWithChildrensTranslations(filterBridge);
+            }
+        }
+
+        root.closeRawDocument();
+
+        String result = byteArrayOutputStream.toString().trim();
+        InputStream originalFileInputStream = loadFromResources("json_mixed_input.xml");
+        String originalFile = getStringFromInputStream(originalFileInputStream);
+        assertEquals(originalFile.trim(), result.trim());
+
+
+    }
+
+    private RawDocument rawDocumentFromTestFile(String filename, LocaleId source, LocaleId target) throws FileNotFoundException, URISyntaxException {
+        InputStream is = loadFromResources(filename);
+        return new RawDocument(is, "UTF-8", source, target);
+
+    }
+
+
+    private InputStream loadFromResources(String fileName) throws FileNotFoundException {
+        InputStream resource = getClass().getResourceAsStream(fileName);
+        if (resource == null) {
+            throw new FileNotFoundException("Unable to load Resource " + fileName
+                    + " stored in package resources.");
+        }
+        return resource;
+    }
+
+    private IFilter getXMLFIlter(String paramsFile) throws IOException {
+        XMLFilter xmlFilter = new XMLFilter();
+        net.sf.okapi.filters.its.Parameters parameters = xmlFilter.getParameters();
+        InputStream originalFileInputStream = loadFromResources(paramsFile);
+        String xmlParams = getStringFromInputStream(originalFileInputStream);
+        parameters.fromString(xmlParams);
+        return xmlFilter;
+    }
+
+    private IFilter getJSONFilter() {
+        JSONFilter jsonFilter = new JSONFilter();
+        net.sf.okapi.filters.json.Parameters parameters = jsonFilter.getParameters();
+        parameters.setExtractStandalone(true);
+        return jsonFilter;
+    }
+
+    private IFilter getHTMLFilter(String paramsFile) throws IOException {
+        HtmlFilter htmlFilter = new HtmlFilter();
+        IParameters parameters = htmlFilter.getParameters();
+        InputStream originalFileInputStream = loadFromResources(paramsFile);
+        String htmlParams = getStringFromInputStream(originalFileInputStream);
+        parameters.fromString(htmlParams);
+        return htmlFilter;
+    }
+
+    private String getStringFromInputStream(InputStream inputStream) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        String line;
+
+        try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+            while ((line = bufferedReader.readLine()) != null) {
+                stringBuilder.append(line).append("\n");
+            }
+        }
+        return stringBuilder.toString();
+    }
+
+
+}

--- a/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/html_filter_params.yml
+++ b/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/html_filter_params.yml
@@ -1,0 +1,268 @@
+assumeWellformed: false
+preserve_whitespace: true
+escapeCharacters: ""
+quoteModeDefined: true
+quoteMode: 0
+useCodeFinder: true
+codeFinderRules: "#v1\ncount.i=1\nrule0=a\nsample=Text <b>bold</b> <a name=\"abc\">\nuseAllRulesWhenTesting.b=false"
+attributes:
+  dir:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+    allElementsExcept: [base, basefront, head, html, meta, param, script]
+  title:
+    ruleTypes: [ATTRIBUTE_TRANS]
+  lang:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+  xml:lang:
+    ruleTypes: [ATTRIBUTE_WRITABLE]
+  aria-label:
+    ruleTypes: [ATTRIBUTE_TRANS]
+elements:
+  meta:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes:
+      content:
+        - [http-equiv, EQUALS, keywords]
+        - - name
+          - EQUALS
+          - [keywords, description]
+    writableLocalizableAttributes:
+      content:
+        - http-equiv
+        - EQUALS
+        - [content-language, content-type]
+      charset: null
+    readOnlyLocalizableAttributes:
+      content:
+        - name
+        - EQUALS
+        - [generator, author, progid, date]
+  area:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [accesskey, area, alt, download]
+  isindex:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [prompt]
+  option:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [label]
+  optgroup:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [label]
+  address:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  dt:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  dd:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h1:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h2:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h3:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h4:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h5:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  h6:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  legend:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [accesskey]
+    idAttributes: [id]
+  li:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [value]
+    idAttributes: [id]
+  marquee:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  p:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+    elementType: paragraph
+  pre:
+    ruleTypes: [TEXTUNIT, PRESERVE_WHITESPACE]
+    idAttributes: [id]
+  td:
+    ruleTypes: [TEXTUNIT]
+    translatableAttributes: [abbr]
+    idAttributes: [id]
+  th:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+    translatableAttributes: [abbr]
+  title:
+    ruleTypes: [TEXTUNIT]
+    idAttributes: [id]
+  track:
+    translatableAttributes: [label, srclang]
+    writableLocalizableAttributes: [src]
+  a:
+    ruleTypes: [INLINE]
+    elementType: link
+    translatableAttributes: [title, accesskey, download]
+    writableLocalizableAttributes: [href]
+  audio:
+    writableLocalizableAttributes: [src]
+  abbr:
+    ruleTypes: [INLINE]
+  acronym:
+    ruleTypes: [INLINE]
+  applet:
+    ruleTypes: [INLINE]
+    translatableAttributes: [alt]
+  b:
+    ruleTypes: [INLINE]
+    elementType: bold
+  base:
+    writableLocalizableAttributes: [src]
+  bdo:
+    ruleTypes: [INLINE]
+  big:
+    ruleTypes: [INLINE]
+  blink:
+    ruleTypes: [INLINE]
+  br:
+    ruleTypes: [INLINE]
+  button:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey, value]
+  cite:
+    ruleTypes: [INLINE]
+  code:
+    ruleTypes: [INLINE]
+  del:
+    ruleTypes: [INLINE]
+  dfn:
+    ruleTypes: [INLINE]
+  em:
+    ruleTypes: [INLINE]
+  embed:
+    ruleTypes: [INLINE]
+  font:
+    ruleTypes: [INLINE]
+  i:
+    ruleTypes: [INLINE]
+    elementType: italic
+  iframe:
+    ruleTypes: [INLINE]
+    translatableAttributes: [srcdoc]
+  img:
+    ruleTypes: [INLINE]
+    elementType: image
+    translatableAttributes: [title, alt]
+    writableLocalizableAttributes: [href, src]
+  input:
+    ruleTypes: [INLINE]
+    translatableAttributes:
+      alt:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      value:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      accesskey:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      title:
+        - type
+        - NOT_EQUALS
+        - [file, hidden, image, Password]
+      placeholder: [type, NOT_EQUALS, dummy]
+  ins:
+    ruleTypes: [INLINE]
+  kbd:
+    ruleTypes: [INLINE]
+  label:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey]
+  map:
+    ruleTypes: [INLINE]
+  menuitem:
+    translatableAttributes: [label]
+  nobr:
+    ruleTypes: [INLINE]
+  object:
+    ruleTypes: [INLINE]
+    translatableAttributes: [standby]
+  param:
+    ruleTypes: [INLINE]
+    translatableAttributes: [value]
+  q:
+    ruleTypes: [INLINE]
+  s:
+    ruleTypes: [INLINE]
+  samp:
+    ruleTypes: [INLINE]
+  small:
+    ruleTypes: [INLINE]
+  select:
+    ruleTypes: [INLINE]
+  span:
+    ruleTypes: [INLINE]
+  spacer:
+    ruleTypes: [INLINE]
+  strike:
+    ruleTypes: [INLINE]
+  strong:
+    ruleTypes: [INLINE]
+  sub:
+    ruleTypes: [INLINE]
+  sup:
+    ruleTypes: [INLINE]
+  table:
+    ruleTypes: [ATTRIBUTES_ONLY]
+    translatableAttributes: [summary]
+  textarea:
+    ruleTypes: [INLINE]
+    translatableAttributes: [accesskey, placeholder]
+  tt:
+    ruleTypes: [INLINE]
+  u:
+    ruleTypes: [INLINE]
+    elementType: underlined
+  var:
+    ruleTypes: [INLINE]
+  wbr:
+    ruleTypes: [INLINE]
+  ruby:
+    ruleTypes: [INLINE]
+  rb:
+    ruleTypes: [INLINE]
+  rt:
+    ruleTypes: [INLINE]
+  rc:
+    ruleTypes: [INLINE]
+  rp:
+    ruleTypes: [INLINE]
+  rbc:
+    ruleTypes: [INLINE]
+  rtc:
+    ruleTypes: [INLINE]
+  symbol:
+    ruleTypes: [INLINE]
+  face:
+    ruleTypes: [INLINE]
+  .*:
+    ruleTypes: [EXCLUDE]
+    conditions: [translate, EQUALS, 'no']
+  style:
+    ruleTypes: [EXCLUDE]
+  stylesheet:
+    ruleTypes: [EXCLUDE]
+  script:
+    ruleTypes: [EXCLUDE]

--- a/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/json_mixed_output.xml
+++ b/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/json_mixed_output.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<translationObjectFile fileType="PAGE" sourcePath="/content/waters/language-masters/zh/analysis-of-water-soluble-vitamins-in-infant-formula">
+    <translationObjectProperties>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">TEST Title</property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Some conent</property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">More content</property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Application Note</property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">Abstract</property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">&lt;p&gt;Sentence one.&lt;sup&gt;1&lt;/sup&gt;&lt;sup&gt;2&lt;/sup&gt; Sentence two.&lt;sup&gt;3&lt;/sup&gt;&lt;/p&gt;&#13;
+            &lt;p&gt;That was a great sentence. Now heres another! &lt;sup&gt;4,5,6&lt;/sup&gt;&lt;/p&gt;&#13;
+        </property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">&lt;p&gt;These things are evil:&lt;/p&gt;
+            &lt;ul&gt;
+            &lt;li&gt;See&lt;/li&gt;
+            &lt;li&gt;Hear&lt;/li&gt;
+            &lt;li&gt;Speak&lt;/li&gt;
+            &lt;/ul&gt;
+        </property>
+        <property isMultiValue="false" nodePath="/test/ab:content" propertyName="xy">[{"0":["x"],"1":["y"]},{"0":["a"],"1":["b"]}]</property>
+    </translationObjectProperties>
+</translationObjectFile>

--- a/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/xml_filter_params.xml
+++ b/filters/base/src/test/resources/com/spartansoftwareinc/ws/okapi/filters/xml_filter_params.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' ?>
+<its:rules version='1.0'
+           xmlns:its='http://www.w3.org/2005/11/its'
+           xmlns:okp='okapi-framework:xmlfilter-options'
+           xmlns:itsx="http://www.w3.org/2008/12/its-extensions"
+>
+ <!-- Do not translate anything by default-->
+ <its:translateRule selector="//*" translate="no"/>
+
+ <!-- These elements can be translated. Ignores <translationObjectFile fileType=translation_export_summary>-->
+ <its:translateRule selector="//translationObjectFile[not(@fileType='translation_export_summary')]//translationObjectProperties//property" translate="yes" itsx:whiteSpaces="preserve"/>
+
+ <!-- More specific rule that will ignore both <translationObjectFile fileType=translation_export_summary> and <property fileUniqueID> -->
+ <!-- <its:translateRule selector="//translationObjectFile[not(@fileType='translation_export_summary')]//translationObjectProperties//property[not(@fileUniqueID)]" translate="yes"/>-->
+
+ <!-- Fixes issues with escaped characters -->
+ <okp:options escapeQuotes="no" escapeGT="yes" escapeNbsp="no"/>
+
+ <!-- See ITS specification at: http://www.w3.org/TR/its/ -->
+</its:rules>

--- a/filters/bundle/pom.xml
+++ b/filters/bundle/pom.xml
@@ -20,6 +20,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.spartansoftwareinc.ws.okapi.filters.aemtranslation</groupId>
+      <artifactId>okapi-ws-filters-aemtranslation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.spartansoftwareinc.ws.okapi.filters.idml</groupId>
       <artifactId>okapi-ws-filters-idml</artifactId>
       <version>${project.version}</version>
@@ -68,6 +73,13 @@
             </goals>
             <configuration>
               <filters>
+                <filter>
+                  <artifact>com.spartansoftwareinc.ws.okapi.filters.aemtranslation:okapi-ws-filters-aemtranslation</artifact>
+                  <excludes>
+                    <exclude>net/sf/okapi/common/**</exclude>
+                    <exclude>org/slf4j/**</exclude>
+                  </excludes>
+                </filter>
                 <filter>
                   <artifact>com.spartansoftwareinc.ws.okapi.filters.idml:okapi-ws-filters-idml</artifact>
                   <excludes>

--- a/filters/bundle/src/main/resources/desc.xml
+++ b/filters/bundle/src/main/resources/desc.xml
@@ -1,4 +1,5 @@
 <components>
+    <filter class="com.spartansoftwareinc.ws.okapi.filters.aemtranslation.AEMTranslationFilter"/>
     <filter class="com.spartansoftwareinc.ws.okapi.filters.idml.IDMLWSOkapiFilter"/>
     <filter class="com.spartansoftwareinc.ws.okapi.filters.json.JSONWSOkapiFilter"/>
     <filter class="com.spartansoftwareinc.ws.okapi.filters.openxml.OpenXMLWSOkapiFilter"/>

--- a/filters/pom.xml
+++ b/filters/pom.xml
@@ -24,5 +24,6 @@
     <module>xliff</module>
     <module>yaml</module>
     <module>bundle</module>
+    <module>aemtranslation</module>
   </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ws.version>10.4.3.195</ws.version>
-    <okapi.version>0.37-SNAPSHOT</okapi.version>
+    <okapi.version>0.37</okapi.version>
     <mainPackage>${project.groupId}</mainPackage>
     <git.basedir>${project.basedir}</git.basedir>
   </properties>


### PR DESCRIPTION
The AEM Translation Filter allows segmentation of AEM Translation Files, which contain embedded JSON and HTML.
The Okapi Multi Filter, developed for the AEM Translation Filter, allows any number of Okapi filters to be layered on top of one another, and can be used in futured development.
Okapi Version was M37 has been released, so we can now use that instead of M37-SNAPSHOT.