### PR TITLE
Fixed issue with Simple Post edit

### DIFF
--- a/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SimplePostEditAutoActionYAMLConfig.java
+++ b/autoactions/mshub/src/main/java/com/spartansoftwareinc/ws/autoactions/hubmt/config/SimplePostEditAutoActionYAMLConfig.java
@@ -31,7 +31,8 @@ public class SimplePostEditAutoActionYAMLConfig {
     }
 
     public List<Action> getActionsForLanguage(String language) {
-        return actions.get(language);
+        final List<Action> actions = this.actions.get(language);
+        return actions != null ? actions : new ArrayList<Action>();
     }
 
     public static class Action {


### PR DESCRIPTION
Fixed bug where Simple Post Edit would error out when a language not specified in config was used.