### PR TITLE
Fix 'INVALID_ARGUMENT: Empty request' error

### DIFF
--- a/mt/googlev3/src/main/java/com/spartansoftwareinc/ws/mt/googlev3/WSGoogleMTv3Adapter.java
+++ b/mt/googlev3/src/main/java/com/spartansoftwareinc/ws/mt/googlev3/WSGoogleMTv3Adapter.java
@@ -191,6 +191,11 @@ public class WSGoogleMTv3Adapter extends WSBaseMTAdapter {
         try (TranslationServiceClient client = TranslationServiceClient.create(settings)) {
             for (WSMTRequest wsMTReq: mtReqs) {
                 String srcText = wsMTReq.getSource();
+                // ignore empty strings, or MT engine returns error, INVALID_ARGUMENT: Empty request.
+                if (srcText.trim().isEmpty()) {
+                    continue;
+                }
+
                 if (handlePlaceholders) {
                     LOG.debug("Original text before mask(): " + srcText);
                     srcText = masker.mask(srcText);


### PR DESCRIPTION
Fix for 'INVALID_ARGUMENT: Empty request' error when assets being MT'ed contain empty segments. Empty segments are not sent to the MT engine.